### PR TITLE
Multi nodes

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -11,7 +11,8 @@
     <h1 id="status">Starting libp2p...</h1>
   </header>
   <main>
-    <input type="file" id="file-input">
+    <input type="text" id="message">
+    <div style="font-size:12px">hit enter after inputting text to send message</div>
     <pre id="output"></pre>
   </main>
   <script type="module" src="./index.js"></script>

--- a/browser/index.js
+++ b/browser/index.js
@@ -30,7 +30,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // Send text entered into input to connections
   messageInput.addEventListener("change", async (event) => {
-    console.log("all connections:", browserNode.getConnections().map(conn => conn.toString()))
     for(let peer of browserNode.getConnections()) {
       try {
         log(`attempting to send message ${event.target.value} to /message/${truncatedId(peer.remotePeer.toString())}`)

--- a/browser/index.js
+++ b/browser/index.js
@@ -1,16 +1,10 @@
 import { Buffer } from 'buffer'
 globalThis.Buffer = Buffer
 
-import { pushable } from "it-pushable";
 import { createLibp2p } from 'libp2p'
-import { Noise } from '@chainsafe/libp2p-noise'
-import { Mplex } from '@libp2p/mplex'
-import { KadDHT } from "@libp2p/kad-dht";
-import { WebSockets } from "@libp2p/websockets";
-import { WebRTCStar } from '@libp2p/webrtc-star';
-
-import { FloodSub } from '@libp2p/floodsub'
+import { nodeConfig } from "./utils/node-config";
 import { pipe } from "it-pipe";
+import { log } from "./utils/log";
 
 if (!import.meta.env.VITE_BOOTSTRAP_NODE_LIST) {
   throw Error("VITE_BOOTSTRAP_NODE_LIST not set in .env")
@@ -20,125 +14,63 @@ if (!import.meta.env.VITE_SIGNAL_SERVER_LIST) {
   throw Error("VITE_SIGNAL_SERVER_LIST not set in .env")
 }
 
+function truncatedId(id, limit = 5) {
+  return id.slice(id.length - limit)
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
-  function log(txt) {
-    console.info(txt);
-    output.textContent += `${txt.trim()}\n`;
-  }
-
-  const dht = new KadDHT({
-    protocolPrefix: import.meta.env.VITE_DHT_PROTOCOL_PREFIX || "/archaeologist-service",
-    clientMode: false
-  })
-
-  const webRtcStar = new WebRTCStar();
-
-  const config = {
-    addresses: {
-      // Add the signaling server address, along with our PeerId to our multiaddrs list
-      // libp2p will automatically attempt to dial to the signaling server so that it can
-      // receive inbound connections from other peers
-      listen: import.meta.env.VITE_SIGNAL_SERVER_LIST.split(",").map(s => s.trim()).map(server => {
-        return `/dns4/${server}/tcp/443/wss/p2p-webrtc-star`
-      })
-    },
-    transports: [
-      new WebSockets(),
-      webRtcStar
-    ],
-    connectionEncryption: [
-      new Noise()
-    ],
-    streamMuxers: [
-      new Mplex()
-    ],
-    peerDiscovery: [
-      webRtcStar.discovery,
-    ],
-    dht,
-    connectionManager: {
-      autoDial: true
-    },
-    pubsub: new FloodSub({
-      enabled: true,
-      canRelayMessage: true,
-      emitSelf: false
-    }),
-  };
-
-  const browserNode = await createLibp2p(config);
-
-  const fileInput = document.getElementById("file-input");
-  const output = document.getElementById("output");
-  const idTruncateLimit = 5;
-
-  fileInput.addEventListener("change", (evt) => {
-    const file = fileInput.files[0];
-
-    const reader = new FileReader();
-
-    reader.addEventListener('load', async (event) => {
-      const fileData = event.target.result;
-      const outboundStream = pushable({});
-
-      try {
-        outboundStream.push(new TextEncoder().encode(fileData));
-        const { stream } = await selectedArweaveConn.newStream('/get-file/1.0.0')
-        pipe(
-          outboundStream,
-          stream,
-        )
-      } catch (err) {
-        log(`Error in peer conn listener: ${err}`)
-      }
-    });
-
-    reader.addEventListener('progress', (event) => {
-      if (event.loaded && event.total) {
-        const percent = (event.loaded / event.total) * 100;
-        console.log(`Progress: ${Math.round(percent)}%`);
-      }
-    });
-
-    reader.readAsDataURL(file);
-  });
-
-  output.textContent = "";
-
-  const discoveredPeers = [];
-
+  const browserNode = await createLibp2p(nodeConfig);
   const nodeId = browserNode.peerId.toString()
-  log(`starting browser node with id: ${nodeId.slice(nodeId.length - idTruncateLimit)}`)
+
+  log(`starting browser node with id: ${truncatedId(nodeId)}`)
   await browserNode.start()
 
-  let selectedArweaveConn;
+  const messageInput = document.getElementById("message");
+  const discoveredPeers = [];
 
-  // Listen for new peers
+  // Send text entered into input to connections
+  messageInput.addEventListener("change", async (event) => {
+    console.log("all connections:", browserNode.getConnections().map(conn => conn.toString()))
+    for(let peer of browserNode.getConnections()) {
+      try {
+        log(`attempting to send message ${event.target.value} to /message/${truncatedId(peer.remotePeer.toString())}`)
+
+        // console.log(JSON.stringify(peer.))
+        const { stream } = await peer.newStream(`/message/${truncatedId(peer.remotePeer.toString())}`)
+        await pipe(
+          [new TextEncoder().encode(event.target.value)],
+          stream
+        )
+      } catch (err) {
+        log(`Error in peer ${peer.remotePeer.toString()} setting up message outbound stream: ${err}`)
+      }
+    }
+  });
+
+  // Log discovered peers
   browserNode.addEventListener('peer:discovery', (evt) => {
     const peerId = evt.detail.id.toString();
 
     if (discoveredPeers.find((p) => p === peerId) === undefined) {
       discoveredPeers.push(peerId);
-      log(`${nodeId.slice(nodeId.length - idTruncateLimit)} discovered: ${peerId.slice(peerId.length - idTruncateLimit)}`)
+      log(`${truncatedId(nodeId)} discovered: ${truncatedId(peerId)}`)
     }
   })
 
-
-  // Listen for peers connecting
+  // Log connected peers
   browserNode.connectionManager.addEventListener('peer:connect', async (evt) => {
-    // in actual app, will need to track all connected nodes, and set this value
-    // based on user input
-    selectedArweaveConn = evt.detail;
-
     const peerId = evt.detail.remotePeer.toString();
-    log(`Connection established to: ${peerId.slice(peerId.length - idTruncateLimit)}`)
+    log(`Connection established to: ${truncatedId(peerId)}`)
   });
 
-  browserNode.pubsub.addEventListener('message', (evt) => {
-    const msg = new TextDecoder().decode(evt.detail.data)
-    const sourceId = evt.detail.from.toString();
-    log(`from ${sourceId.slice(sourceId.length - idTruncateLimit)}: ${msg}`)
-  })
+  // Log disconnected peers
+  browserNode.connectionManager.addEventListener('peer:disconnect', async (evt) => {
+    const peerId = evt.detail.remotePeer.toString();
+    log(`Connection dropped from: ${truncatedId(peerId)}`)
+  });
 
-  browserNode.pubsub.subscribe("env-config")
+  // Unload connections when browser closes (this may not be necessary)
+  window.addEventListener("beforeunload",  (e) => {
+    browserNode.connectionManager.closeConnections()
+  });
 });

--- a/browser/package.json
+++ b/browser/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "DEBUG=libp2p:webrtc-star vite"
+    "start": "vite"
   },
   "license": "MIT",
   "dependencies": {

--- a/browser/package.json
+++ b/browser/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "vite"
+    "start": "DEBUG=libp2p:webrtc-star vite"
   },
   "license": "MIT",
   "dependencies": {

--- a/browser/utils/log.js
+++ b/browser/utils/log.js
@@ -1,0 +1,6 @@
+const output = document.getElementById("output");
+
+export function log(txt) {
+  console.info(txt);
+  output.textContent += `${txt.trim()}\n`;
+}

--- a/browser/utils/node-config.js
+++ b/browser/utils/node-config.js
@@ -1,0 +1,38 @@
+import {KadDHT} from "@libp2p/kad-dht";
+import {WebRTCStar} from "@libp2p/webrtc-star";
+import {Noise} from "@chainsafe/libp2p-noise";
+import {Mplex} from "@libp2p/mplex";
+
+const dht = new KadDHT({
+  protocolPrefix: import.meta.env.VITE_DHT_PROTOCOL_PREFIX || "/archaeologist-service",
+  clientMode: false
+})
+
+const webRtcStar = new WebRTCStar();
+
+export const nodeConfig = {
+  addresses: {
+    // Add the signaling server address, along with our PeerId to our multiaddrs list
+    // libp2p will automatically attempt to dial to the signaling server so that it can
+    // receive inbound connections from other peers
+    listen: import.meta.env.VITE_SIGNAL_SERVER_LIST.split(",").map(s => s.trim()).map(server => {
+      return `/dns4/${server}/tcp/443/wss/p2p-webrtc-star`
+    })
+  },
+  transports: [
+    webRtcStar
+  ],
+  connectionEncryption: [
+    new Noise()
+  ],
+  streamMuxers: [
+    new Mplex()
+  ],
+  peerDiscovery: [
+    webRtcStar.discovery,
+  ],
+  dht,
+  connectionManager: {
+    autoDial: true
+  }
+}

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -30,3 +30,11 @@ retrieveOnchainData(web3Interface);
 
 setInterval(() => retrieveOnchainData(web3Interface), 300000); // refetch every 5mins
 setupEventListeners(web3Interface);
+
+[`exit`, `SIGINT`, `SIGUSR1`, `SIGUSR2`, `uncaughtException`, `SIGTERM`].forEach((eventType) => {
+  process.on(eventType, async () => {
+    console.log(`received exit event: ${eventType}`)
+    await arch.shutdown();
+    process.exit(2);
+  });
+})

--- a/service/src/models/archaeologist.ts
+++ b/service/src/models/archaeologist.ts
@@ -137,8 +137,8 @@ export class Archaeologist {
   // TODO temporary function for testing streaming
   async setupMessageStream() {
     const msgProtocol = `/message/${this.truncatedId(this.peerId.toString())}`
-    console.log('my message protocol:', msgProtocol)
-    this.node.handle([msgProtocol], ({ protocol, stream }) => {
+    archLogger.info(`listening to stream on protocol: ${msgProtocol}`)
+    this.node.handle([msgProtocol], ({ stream }) => {
       pipe(
         stream,
         async function (source) {
@@ -155,8 +155,8 @@ export class Archaeologist {
   }
 
   // TODO - pubsub is currently disabled,
-  // determine if we want to re-enable it or clean related pubsub
-  // functions up (either make pubsub optional or remove the functions)
+  // determine if we want to re-enable it, make it optional or
+  // remove the related functions
   async publishEnvConfig() {
     const configStr = JSON.stringify(this.envConfig);
     this.publish(this.envTopic, configStr).catch(err => {

--- a/service/src/models/archaeologist.ts
+++ b/service/src/models/archaeologist.ts
@@ -5,7 +5,6 @@ import { createNode } from "../utils/create-node";
 import { NodeConfig } from "./node-config";
 import { PublicEnvConfig } from "./env-config";
 import { pipe } from "it-pipe";
-import { solidityKeccak256 } from "ethers/lib/utils";
 import { PeerId } from "@libp2p/interfaces/dist/src/peer-id";
 import { archLogger } from "../utils/chalk-theme";
 import { ethers, Wallet } from "ethers";
@@ -57,26 +56,22 @@ export class Archaeologist {
     this.listenAddressesConfig = options.listenAddressesConfig
   }
 
-  async setupIncomingConfigStream() {
-    // TODO: Do we need this get-file protocol anymore?
-    this.node.handle(['/get-file/1.0.0'], async ({ stream }) => {
-      try {
-        await pipe(stream, async (source) => {
-          for await (const data of source) {
-            const decoded = new TextDecoder().decode(data);
-            const hashed = solidityKeccak256(["string"], [decoded]);
+  truncatedId(id, limit = 5): string {
+    return id.slice(id.length - limit)
+  }
 
-            console.log("arch hashed", hashed);
-          }
-        })
-      } catch (err) {
-        console.log("problem with pipe", err)
-      }
-    });
+  async setupIncomingConfigStream() {
+    // TODO temporary function for testing
+    await this.setupMessageStream();
 
     this.node.handle(['/validate-arweave'], async ({ stream }) => {
       try {
         const streamToBrowser = (result: string) => {
+          // TODO -- outboundStream can possibly be replaced (in pipe) with:
+          // pipe(
+          //   [new TextEncoder().encode(result)],
+          //   stream
+          // )
           const outboundStream = pushable({})
           outboundStream.push(new TextEncoder().encode(result))
           pipe(
@@ -105,7 +100,7 @@ export class Archaeologist {
           }
         })
       } catch (err) {
-        console.log("problem with pipe", err)
+        archLogger.error(`problem with pipe in validate-arweave: ${err}`)
       }
     })
   }
@@ -118,6 +113,50 @@ export class Archaeologist {
     return this.node;
   }
 
+  async createLibp2pNode(idFilePath?: string): Promise<Libp2p> {
+    this.peerId = this.peerId ?? await loadPeerIdFromFile(idFilePath)
+
+    if (this.listenAddressesConfig) {
+      const { ipAddress, tcpPort, wsPort, signalServerList } = this.listenAddressesConfig!
+      this.listenAddresses = genListenAddresses(
+        ipAddress, tcpPort, signalServerList, this.peerId.toJSON().id
+      )
+    }
+
+    this.nodeConfig.add("peerId", this.peerId)
+    this.nodeConfig.add("addresses", { listen: this.listenAddresses })
+
+    return createNode(this.name, this.nodeConfig.configObj);
+  }
+
+  async shutdown() {
+    archLogger.info(`${this.name} is stopping...`)
+    await this.node.stop()
+  }
+
+  // TODO temporary function for testing streaming
+  async setupMessageStream() {
+    const msgProtocol = `/message/${this.truncatedId(this.peerId.toString())}`
+    console.log('my message protocol:', msgProtocol)
+    this.node.handle([msgProtocol], ({ protocol, stream }) => {
+      pipe(
+        stream,
+        async function (source) {
+          for await (const msg of source) {
+            const decoded = new TextDecoder().decode(msg);
+            archLogger.notice( `received message ${decoded}`);
+          }
+        }
+      ).finally(() => {
+        // clean up resources
+        stream.close()
+      })
+    })
+  }
+
+  // TODO - pubsub is currently disabled,
+  // determine if we want to re-enable it or clean related pubsub
+  // functions up (either make pubsub optional or remove the functions)
   async publishEnvConfig() {
     const configStr = JSON.stringify(this.envConfig);
     this.publish(this.envTopic, configStr).catch(err => {
@@ -133,21 +172,5 @@ export class Archaeologist {
     catch (err) {
       archLogger.error(err);
     }
-  }
-
-  async createLibp2pNode(idFilePath?: string): Promise<Libp2p> {
-    this.peerId = this.peerId ?? await loadPeerIdFromFile(idFilePath)
-
-    if (this.listenAddressesConfig) {
-      const { ipAddress, tcpPort, wsPort, signalServerList } = this.listenAddressesConfig!
-      this.listenAddresses = genListenAddresses(
-        ipAddress, tcpPort, wsPort, signalServerList, this.peerId.toJSON().id
-      )
-    }
-
-    this.nodeConfig.add("peerId", this.peerId)
-    this.nodeConfig.add("addresses", { listen: this.listenAddresses })
-
-    return createNode(this.name, this.nodeConfig.configObj, () => setTimeout(() => this.publishEnvConfig(), 400));
   }
 }

--- a/service/src/models/node-config.ts
+++ b/service/src/models/node-config.ts
@@ -1,5 +1,4 @@
 import { TCP } from "@libp2p/tcp";
-import { WebSockets } from "@libp2p/websockets";
 import { WebRTCStar } from "@libp2p/webrtc-star";
 import wrtc from '@koush/wrtc'
 import { KadDHT } from "@libp2p/kad-dht";
@@ -7,9 +6,6 @@ import { Noise } from "@chainsafe/libp2p-noise";
 import { Mplex } from "@libp2p/mplex";
 import { Bootstrap } from "@libp2p/bootstrap";
 import { Libp2pOptions } from "libp2p";
-
-
-import { FloodSub } from '@libp2p/floodsub'
 
 interface NodeConfigParams {
   bootstrapList?: string[],
@@ -22,12 +18,8 @@ const webRtcStar = new WebRTCStar({ wrtc });
 
 export class NodeConfig {
   public configObj: Libp2pOptions = {
-    // There are some type issues in libp2p interfaces
-    // which necessitate these ts-ignore statements
     transports: [
       new TCP(),
-      // @ts-ignore
-      new WebSockets(),
       // @ts-ignore
       webRtcStar,
     ],
@@ -44,11 +36,9 @@ export class NodeConfig {
     peerDiscovery: [
       webRtcStar.discovery
     ],
-    pubsub: new FloodSub({
-      enabled: true,
-      canRelayMessage: true,
-      emitSelf: false
-    }),
+    connectionManager: {
+      autoDial: false
+    },
   }
 
   constructor(options: NodeConfigParams = {}) {

--- a/service/src/test.ts
+++ b/service/src/test.ts
@@ -1,30 +1,37 @@
 import 'dotenv/config'
-import { getMultiAddresses } from "./utils";
+import { getMultiAddresses, loadPeerIdFromFile } from "./utils";
 import { validateEnvVars } from "./utils/validateEnv";
 import { randomArchVals } from "./utils/random-arch-gen.js";
 import { Archaeologist } from "./models/archaeologist";
 import { Libp2p } from "libp2p";
 import { ethers } from 'ethers';
 
+function randomIntFromInterval(min, max) { // min and max included
+  return Math.floor(Math.random() * (max - min + 1) + min)
+}
+
 /**
  * This file is used to test multiple archaeologists locally
  * Set numOfArchsToGenerate for how many archaeologists to generate
  */
 
-const numOfArchsToGenerate = 3
-const startingTcpPort = 8000
-const startingWsPort = 10000
+const numOfArchsToGenerate = 1
+const startingTcpPort = randomIntFromInterval(10000, 15000)
+const startingWsPort = randomIntFromInterval(15001, 20000)
 const encryptionWallet = new ethers.Wallet(process.env.ENCRYPTION_PRIVATE_KEY!);
 
 const config = validateEnvVars(true);
-let archInitNodePromises: Promise<Libp2p>[] = [];
-
+let archInitNodePromises: Promise<void | Libp2p>[] = [];
 
 /**
  * Setup and start Bootstrap Node
  */
 
-const { peerId, listenAddresses } = await randomArchVals(startingTcpPort, startingWsPort)
+// const peerId = await loadPeerIdFromFile();
+
+const { listenAddresses, peerId } = await randomArchVals(
+  startingTcpPort, startingWsPort
+)
 
 const bootstrap = new Archaeologist({
   name: "bootstrap",
@@ -35,7 +42,6 @@ const bootstrap = new Archaeologist({
 
 await bootstrap.initNode({ config, encryptionWallet })
 
-
 /**
  * Setup and start non-bootstrap nodes
  */
@@ -43,21 +49,30 @@ await bootstrap.initNode({ config, encryptionWallet })
 const bootstrapList = getMultiAddresses(bootstrap.node)
 const archs: Archaeologist[] = []
 
+// Nodes will start with this delay between them
+const delayIncrement = 2000;
+let delay = 0;
+
 for (let i = 1; i <= numOfArchsToGenerate; i++) {
   const { peerId, listenAddresses } = await randomArchVals(startingTcpPort + i, startingWsPort + i)
   const arch = new Archaeologist({
     name: `arch${i}`,
     peerId,
     listenAddresses,
-    bootstrapList
+    bootstrapList,
   })
 
-  archInitNodePromises.push(arch.initNode({ config, encryptionWallet }))
+  archInitNodePromises.push(
+    new Promise(resolve => setTimeout(resolve, delay))
+      .then(() => {
+        return arch.initNode({ config, encryptionWallet })
+      })
+  )
   archs.push(arch)
+  delay += delayIncrement
 }
 
 await Promise.all(archInitNodePromises);
-
 
 /**
  * Handle streams for all non-bootstrap nodes
@@ -66,6 +81,18 @@ await Promise.all(archInitNodePromises);
 for (let i = 0; i < numOfArchsToGenerate; i++) {
   archs[i].setupIncomingConfigStream()
 }
+
+[`exit`, `SIGINT`, `SIGUSR1`, `SIGUSR2`, `uncaughtException`, `SIGTERM`].forEach((eventType) => {
+  process.on(eventType, async () => {
+    console.log(`received exit event: ${eventType}`)
+
+    await bootstrap.shutdown()
+    for (let i = 0; i < numOfArchsToGenerate; i++) {
+      await archs[i].shutdown()
+    }
+    process.exit(2);
+  });
+})
 
 
 

--- a/service/src/test.ts
+++ b/service/src/test.ts
@@ -27,9 +27,9 @@ let archInitNodePromises: Promise<void | Libp2p>[] = [];
  * Setup and start Bootstrap Node
  */
 
-// const peerId = await loadPeerIdFromFile();
+const peerId = await loadPeerIdFromFile();
 
-const { listenAddresses, peerId } = await randomArchVals(
+const { listenAddresses } = await randomArchVals(
   startingTcpPort, startingWsPort
 )
 

--- a/service/src/utils/create-node.ts
+++ b/service/src/utils/create-node.ts
@@ -12,7 +12,7 @@ import { setupNodeEventListeners } from "./node-event-listeners";
 export async function createNode(
   name: string,
   configOptions: Libp2pOptions,
-  connectCallback: () => void,
+  connectCallback?: () => void,
 ): Promise<Libp2p> {
   const node = await createLibp2p(configOptions);
   setupNodeEventListeners(node, name, connectCallback);

--- a/service/src/utils/listen-addresses.ts
+++ b/service/src/utils/listen-addresses.ts
@@ -1,16 +1,11 @@
 export const genListenAddresses = (
   ipAddress: string,
   tcpPort: number | string,
-  wsPort: number | string,
   servers: string[],
   peerId?: string
 ): string[] => {
-  return [
-    tcpListenAddress(ipAddress, tcpPort),
-    wsListenAddress(ipAddress, wsPort),
-  ].concat(
-    ssListenAddresses(servers, peerId)
-  )
+  return [tcpListenAddress(ipAddress, tcpPort)]
+    .concat(ssListenAddresses(servers, peerId))
 }
 
 export const tcpListenAddress = (
@@ -18,13 +13,6 @@ export const tcpListenAddress = (
   port: number | string
 ) => {
   return `/ip4/${ipAddress}/tcp/${port}`
-}
-
-export const wsListenAddress = (
-  ipAddress: string,
-  port: number | string
-): string => {
-  return `/ip4/${ipAddress}/tcp/${port}/ws`
 }
 
 export const ssListenAddresses = (

--- a/service/src/utils/node-event-listeners.ts
+++ b/service/src/utils/node-event-listeners.ts
@@ -13,7 +13,7 @@ function formatDP(name, peerId) {
 export function setupNodeEventListeners(
     node: Libp2p,
     name: string,
-    connectCallback: () => void,
+    connectCallback?: () => void,
 ) {
     node.addEventListener('peer:discovery', (evt) => {
         const peerId = evt.detail.id.toString();
@@ -29,7 +29,9 @@ export function setupNodeEventListeners(
         const peerId = evt.detail.remotePeer.toString()
         archLogger.info(`${name}: Connection established to ${peerId.slice(peerId.length - idTruncateLimit)}`);
 
-        connectCallback();
+        if (connectCallback) {
+            connectCallback();
+        }
     })
 
     node.connectionManager.addEventListener('peer:disconnect', (evt) => {

--- a/service/src/utils/random-arch-gen.ts
+++ b/service/src/utils/random-arch-gen.ts
@@ -5,11 +5,18 @@ import { createFromJSON } from "@libp2p/peer-id-factory";
 const localhost = '127.0.0.1'
 const starServers = process.env.SIGNAL_SERVER_LIST
 
-export const randomArchVals = async (tcpPort, wsPort) => {
-  const randomPeerId = await PeerId.create({ bits: 1024, keyType: 'Ed25519' })
-  const peerIdJson = randomPeerId.toJSON()
-  const peerId = await createFromJSON(peerIdJson)
-  const listenAddresses = genListenAddresses(localhost, tcpPort, wsPort, [starServers!], peerIdJson.id)
+export const randomArchVals = async (tcpPort: string | number, number, existingPeerId?) => {
+  let peerIdJson, peerId
+  if (!existingPeerId) {
+    const randomPeerId = await PeerId.create({ bits: 1024, keyType: 'Ed25519' })
+    peerIdJson = randomPeerId.toJSON()
+    peerId = await createFromJSON(peerIdJson)
+  } else {
+    peerId = existingPeerId
+    peerIdJson = peerId.toJSON()
+  }
+
+  const listenAddresses = genListenAddresses(localhost, tcpPort, [starServers!], peerIdJson.id)
   return { peerId, listenAddresses }
 }
 


### PR DESCRIPTION
## Overview
Makes some tweaks to enable multi-arch local setup for testing, as well as multi-arch communication via streams.

## Changes
1. Removes websockets transport as it isn't necessary right now. Arch nodes can communicate over TCP, and Browser->Arch  will happen over webrtc-star.

2. Update the browser stream to no longer use the `pushable` `outboundStream` --- using this special type of stream was only allowing a single stream to receive messages locally.

The `outboundStream` is convenient b/c you can push to it without calling `pipe` repeatedly, but for now we can accomplish what we need to by calling `pipe` with the stream data every time we need to send a message.

3. Adds a shutdown routine to the nodes which gets triggered whenever the service receives an exit event type.

4. Remove `file` protocol stream and add a temporary `message` protocol stream to test messaging between browser->arch.

5. Removed the pubsub from node configs. Still left in the utility methods -- need to discuss if we want to keep these moving forward (potentially making them optional)


## Notes
**The multi-node setup works way more reliably when running multiple nodes on their own threads (i.e. in their own terminal)** rather than running multiple on one thread. As such, I have set the default test script to only create 1 arch node. This test script also creates a bootstrap node, which may not be necessary -- I set it up to use the same peerId for all the bootstrap nodes, which is kind of whack and may not be necessary either. Will regroup on this soon.

If the browser attempts to create a new stream on a peer which it is no longer connected to, the `newStream` method hangs and does not exit correctly (god knows why). This can lead to problems --  I added some cleanup code to detect when the service exits, but more may need to be done here to ensure connections get cleaned up properly.

## Testing
Tested the following scenarios:

1. Run multiple nodes locally (~20)
2. Tested that the browser discovers all the nodes on bootup and auto-connects to them.
3. Refreshed browser multiple times and confirm previous step works.
7. Start new arch nodes while browser node is running and confirm the browser finds + connects to it.
8. Stop and start new arch nodes and confirm the browser disconnects from exited node
9. Repeat step 5 and confirm messages can still be sent 