### PR TITLE
Arweave data update

### DIFF
--- a/service/src/utils/arweave.ts
+++ b/service/src/utils/arweave.ts
@@ -6,6 +6,10 @@ import { Web3Interface } from "scripts/web3-interface";
 import { archLogger } from "../logger/chalk-theme";
 import { SarcophagusState } from "./onchain-data";
 
+const privateKeyPad = (privKey: string): string => {
+  return privKey.startsWith("0x") ? privKey : `0x${privKey}`;
+}
+
 export const generateArweaveInstance = (): Arweave => {
   return Arweave.init({
     host: process.env.ARWEAVE_HOST,
@@ -29,7 +33,7 @@ export const fetchAndValidateShardOnArweave = async (
     const encryptedShard = shards[publicKey];
 
     const decrypted = await decrypt(
-      Buffer.from(ethers.utils.arrayify(process.env.ENCRYPTION_PRIVATE_KEY!)),
+      Buffer.from(ethers.utils.arrayify(privateKeyPad(process.env.ENCRYPTION_PRIVATE_KEY!))),
       Buffer.from(ethers.utils.arrayify(encryptedShard))
     );
 
@@ -71,7 +75,7 @@ export const fetchAndDecryptShard = async (
     const encryptedShard = shards[web3Interface.encryptionWallet.publicKey];
 
     const decrypted = await decrypt(
-      Buffer.from(ethers.utils.arrayify(process.env.ENCRYPTION_PRIVATE_KEY!)),
+      Buffer.from(ethers.utils.arrayify(privateKeyPad(process.env.ENCRYPTION_PRIVATE_KEY!))),
       Buffer.from(ethers.utils.arrayify(encryptedShard))
     );
 

--- a/service/src/utils/arweave.ts
+++ b/service/src/utils/arweave.ts
@@ -23,12 +23,9 @@ export const fetchAndValidateShardOnArweave = async (
 ): Promise<boolean> => {
   try {
     const arweaveInstance = generateArweaveInstance();
-    const data = await arweaveInstance.transactions.getData(arweaveShardsTxId, {
-      decode: true,
-      string: true,
-    });
+    const response = await arweaveInstance.api.get(arweaveShardsTxId);
 
-    const shards = JSON.parse(data as string);
+    const shards = response.data;
     const encryptedShard = shards[publicKey];
 
     const decrypted = await decrypt(


### PR DESCRIPTION
Use api data method for pulling data for signature, since data won't yet be on L1.

Continue using `getData` to pull data from L1 for unwrapping.

Pad private key with "0x" for decryption, as `ethers.utils.arrayify` doesnt work without it. 