### PR TITLE
Update-arweave-fetch

### DIFF
--- a/service/src/cli/commands/view.ts
+++ b/service/src/cli/commands/view.ts
@@ -38,7 +38,7 @@ export class View implements Command {
       logCallout(async () => {
         const sarcoBalance = await getSarcoBalance(this.web3Interface);
         const ethBalance = await getEthBalance(this.web3Interface);
-        logBalances(sarcoBalance, ethBalance);
+        logBalances(sarcoBalance, ethBalance, this.web3Interface.ethWallet.address);
       });
     }
   }

--- a/service/src/cli/utils.ts
+++ b/service/src/cli/utils.ts
@@ -78,20 +78,24 @@ export const logBalances = (
   ethBalance: BigNumber,
   address: string,
 ): void => {
-  console.log(` YOUR BALANCES (${address}):\n`);
+  console.log(`YOUR BALANCES (${address}):\n`);
 
   const balances = [
     {
-      balance: formatEther(sarcoBalance),
+      balance: "",
+      ticker: "",
+    },
+    {
+      balance: ` > ${formatEther(sarcoBalance)}`,
       ticker: "SARCO",
     },
     {
-      balance: formatEther(ethBalance),
+      balance: ` > ${formatEther(ethBalance)}`,
       ticker: "ETH",
     }
   ];
 
-  console.log(columnify(balances, { minWidth: 20 }));
+  console.log(columnify(balances, { minWidth: 30 }));
 };
 
 export const randomIntFromInterval = (min, max) => {

--- a/service/src/utils/arweave.ts
+++ b/service/src/utils/arweave.ts
@@ -36,7 +36,6 @@ const fetchAndDecryptShardFromArweave = async (txId: string, publicKey: string):
       const jsonData = JSON.parse(data as string) as Record<string, string>;
       return jsonData;
     } catch (e) {
-      console.log('fetch failed');
       return await fetchDataFallback();
     }
   };
@@ -45,17 +44,18 @@ const fetchAndDecryptShardFromArweave = async (txId: string, publicKey: string):
   let _nRetries = 1;
 
   const fetchDataFallback = async (): Promise<Record<string, string>> => {
-    console.log('use fallback');
     try {
       const response = await arweaveInstance.api.get(txId);
+
+      if (response.data.error) throw response.data;
 
       if (_timeout) {
         clearTimeout(_timeout);
         _timeout = undefined;
       }
       return response.data as Record<string, string>;
-    } catch {
-      console.log(`fallback ${_nRetries} failed`);
+    } catch (e) {
+      console.log(`fallback ${_nRetries} failed`, e);
       if (_nRetries >= MAX_ARWEAVE_RETRIES) return {};
 
       _nRetries = _nRetries + 1;

--- a/service/src/utils/arweave.ts
+++ b/service/src/utils/arweave.ts
@@ -36,6 +36,7 @@ const fetchAndDecryptShardFromArweave = async (txId: string, publicKey: string):
       const jsonData = JSON.parse(data as string) as Record<string, string>;
       return jsonData;
     } catch (e) {
+      console.log('fetch failed');
       return await fetchDataFallback();
     }
   };
@@ -44,6 +45,7 @@ const fetchAndDecryptShardFromArweave = async (txId: string, publicKey: string):
   let _nRetries = 1;
 
   const fetchDataFallback = async (): Promise<Record<string, string>> => {
+    console.log('use fallback');
     try {
       const response = await arweaveInstance.api.get(txId);
 
@@ -53,10 +55,12 @@ const fetchAndDecryptShardFromArweave = async (txId: string, publicKey: string):
       }
       return response.data as Record<string, string>;
     } catch {
+      console.log(`fallback ${_nRetries} failed`);
       if (_nRetries >= MAX_ARWEAVE_RETRIES) return {};
 
       _nRetries = _nRetries + 1;
       return new Promise((resolve, _) => {
+        console.log('retrying');
         _timeout = setTimeout(() => fetchDataFallback().then((data => resolve(data))), ARWEAVE_RETRY_INTERVAL);
       });
     }

--- a/service/src/utils/onchain-data.ts
+++ b/service/src/utils/onchain-data.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers";
+import { BigNumber, ethers } from "ethers";
 import { Web3Interface } from "scripts/web3-interface";
 import { fetchAndDecryptShard } from "./arweave";
 import { archLogger } from "../logger/chalk-theme";
@@ -120,7 +120,10 @@ export async function unwrapSarcophagus(web3Interface: Web3Interface, sarcoId: s
   }
 
   try {
-    await web3Interface.archaeologistFacet.unwrapSarcophagus(sarcoId, decryptedShard);
+    await web3Interface.archaeologistFacet.unwrapSarcophagus(
+      sarcoId,
+      ethers.utils.arrayify(decryptedShard) // TODO: Might need an extra `Buffer.from`. `unwrapSarcophagus` expects a solidity bytes type, `decryptedShard` is a hex string
+    );
 
     inMemoryStore.sarcophagi = inMemoryStore.sarcophagi.filter(s => s.id !== sarcoId);
     archLogger.notice("Unwrapped successfully!");


### PR DESCRIPTION
Based on #49

Adds a retry mechanism to arweave fetch that attempts to use `getData`, and uses the `api.get` as a fallback in case of an exception.

Fallback will be retried up to `MAX_ARWEAVE_RETRIES` times, with `ARWEAVE_RETRY_INTERVAL` milliseconds between retries.