### PR TITLE
Remove tcp

### DIFF
--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -27,19 +27,13 @@ export class Start implements Command {
   }
 
   async registerAndStartRandomArch() {
-    const startingTcpPort = randomIntFromInterval(10000, 15000);
-    const startingWsPort = randomIntFromInterval(15001, 20000);
-
-    const {peerId, listenAddresses} = await randomTestArchVals({
-      tcpPort: startingTcpPort,
-      wsPort: startingWsPort
-    });
+    const {peerId, listenAddresses} = await randomTestArchVals({});
 
     this.defaultProfileParams.peerId = peerId.toString();
     await this.registerOrUpdateArchaeologist(this.defaultProfileParams);
 
     await startService({
-      nodeName: `random arch: ${startingWsPort}`,
+      nodeName: `random arch`,
       peerId,
       listenAddresses
     })

--- a/src/models/archaeologist.ts
+++ b/src/models/archaeologist.ts
@@ -15,9 +15,6 @@ import { inMemoryStore } from "../utils/onchain-data";
 import { SarcophagusValidationError, StreamCommsError } from "../utils/error-codes";
 
 export interface ListenAddressesConfig {
-  ipAddress: string;
-  tcpPort: string;
-  wsPort: string;
   signalServerList: string[];
 }
 
@@ -87,10 +84,8 @@ export class Archaeologist {
     this.peerId = this.peerId ?? (await loadPeerIdFromFile(idFilePath));
 
     if (this.listenAddressesConfig) {
-      const { ipAddress, tcpPort, wsPort, signalServerList } = this.listenAddressesConfig!;
+      const { signalServerList } = this.listenAddressesConfig!;
       this.listenAddresses = genListenAddresses(
-        ipAddress,
-        tcpPort,
         signalServerList,
         this.peerId.toJSON().id
       );

--- a/src/scripts/run_local/start_multiple.ts
+++ b/src/scripts/run_local/start_multiple.ts
@@ -3,18 +3,10 @@ import { randomTestArchVals } from "../../utils/random-arch-gen.js";
 import { Libp2p } from "libp2p";
 import { startService } from "../../start_service";
 
-function _randomIntFromInterval(min, max) {
-  // min and max included
-  return Math.floor(Math.random() * (max - min + 1) + min);
-}
-
 /**
  * Run multiple archaeologists locally
  */
 export async function startMultipleLocal(numOfArchsToGenerate: number) {
-  const startingTcpPort = _randomIntFromInterval(10000, 15000);
-  const startingWsPort = _randomIntFromInterval(15001, 20000);
-
   let archInitNodePromises: Promise<void | Libp2p>[] = [];
 
   // Nodes will start with this delay between them
@@ -23,8 +15,6 @@ export async function startMultipleLocal(numOfArchsToGenerate: number) {
 
   for (let i = 1; i <= numOfArchsToGenerate; i++) {
     const { peerId, listenAddresses } = await randomTestArchVals({
-      tcpPort: startingTcpPort + i,
-      wsPort: startingWsPort + i,
       isLocal: true
     });
 

--- a/src/start_service.ts
+++ b/src/start_service.ts
@@ -27,9 +27,6 @@ export async function startService(opts: {
     listenAddressesConfig:
       listenAddresses === undefined
         ? {
-            ipAddress: process.env.IP_ADDRESS!,
-            tcpPort: process.env.TCP_PORT!,
-            wsPort: process.env.WS_PORT!,
             signalServerList: process.env.SIGNAL_SERVER_LIST!.split(",").map(s => s.trim()),
           }
         : undefined,

--- a/src/utils/listen-addresses.ts
+++ b/src/utils/listen-addresses.ts
@@ -1,19 +1,11 @@
 import { getLocalStarSignallingPort } from "../scripts/run_local/helpers";
 
 export const genListenAddresses = (
-  ipAddress: string,
-  tcpPort: number | string,
   servers: string[],
   peerId?: string,
   isLocal?: boolean
 ): string[] => {
-  return [tcpListenAddress(ipAddress, tcpPort)].concat(
-    ssListenAddresses(isLocal === true, servers, peerId)
-  );
-};
-
-export const tcpListenAddress = (ipAddress: string, port: number | string) => {
-  return `/ip4/${ipAddress}/tcp/${port}`;
+  return ssListenAddresses(isLocal === true, servers, peerId);
 };
 
 export const ssListenAddresses = (

--- a/src/utils/random-arch-gen.ts
+++ b/src/utils/random-arch-gen.ts
@@ -6,12 +6,10 @@ const localhost = "127.0.0.1";
 const localStarServer = localhost;
 
 export const randomTestArchVals = async (opts: {
-  tcpPort: string | number;
-  wsPort: string | number;
   existingPeerId?;
   isLocal?: boolean;
 }) => {
-  const { tcpPort, existingPeerId, isLocal } = opts;
+  const { existingPeerId, isLocal } = opts;
 
   let peerIdJson, peerId;
   if (!existingPeerId) {
@@ -24,8 +22,6 @@ export const randomTestArchVals = async (opts: {
   }
 
   const listenAddresses = genListenAddresses(
-    localhost,
-    tcpPort,
     isLocal ? [localStarServer] : process.env.SIGNAL_SERVER_LIST!.split(",").map(s => s.trim()),
     peerIdJson.id,
     isLocal

--- a/src/utils/validateEnv.ts
+++ b/src/utils/validateEnv.ts
@@ -51,9 +51,6 @@ export function validateEnvVars(): PublicEnvConfig {
 }
 
 function validateLibp2pEnvVars(isLocal?: boolean) {
-  // _tryReadEnv("IP_ADDRESS", process.env.IP_ADDRESS, { required: !isLocal });
-  // _tryReadEnv("TCP_PORT", process.env.TCP_PORT || DEFAULT_TCP_PORT);
-  // _tryReadEnv("WS_PORT", process.env.WS_PORT || DEFAULT_WS_PORT);
   _tryReadEnv("SIGNAL_SERVER_LIST", process.env.SIGNAL_SERVER_LIST);
   _tryReadEnv("BOOTSTRAP_LIST", process.env.BOOTSTRAP_LIST);
 }

--- a/src/utils/validateEnv.ts
+++ b/src/utils/validateEnv.ts
@@ -51,9 +51,9 @@ export function validateEnvVars(): PublicEnvConfig {
 }
 
 function validateLibp2pEnvVars(isLocal?: boolean) {
-  _tryReadEnv("IP_ADDRESS", process.env.IP_ADDRESS, { required: !isLocal });
-  _tryReadEnv("TCP_PORT", process.env.TCP_PORT || DEFAULT_TCP_PORT);
-  _tryReadEnv("WS_PORT", process.env.WS_PORT || DEFAULT_WS_PORT);
+  // _tryReadEnv("IP_ADDRESS", process.env.IP_ADDRESS, { required: !isLocal });
+  // _tryReadEnv("TCP_PORT", process.env.TCP_PORT || DEFAULT_TCP_PORT);
+  // _tryReadEnv("WS_PORT", process.env.WS_PORT || DEFAULT_WS_PORT);
   _tryReadEnv("SIGNAL_SERVER_LIST", process.env.SIGNAL_SERVER_LIST);
   _tryReadEnv("BOOTSTRAP_LIST", process.env.BOOTSTRAP_LIST);
 }


### PR DESCRIPTION
### Based on https://github.com/sarcophagus-org/sarcophagus-v2-archaeologist-service/pull/54

## Overview
Remove all TCP / WS related code. The node relies purely on webrtc for discovery and connections. If the archs ever need to connect or discover each other in the future, we may want to add the TCP/WS transports back in. 

Tested these changes on local arch + arch with external IP. 