### PR TITLE
Wrtc (re)-fix; upgrade contacts (0.4.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,7 @@
         "libp2p": "^0.40.0",
         "node-schedule": "^2.1.0",
         "peer-id": "^0.16.0",
-        "prompt-sync": "^4.2.0",
-        "wrtc": "^0.4.7"
+        "prompt-sync": "^4.2.0"
       },
       "bin": {
         "cli": "build/src/cli/run.js"
@@ -12413,24 +12412,6 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
-    "node_modules/wrtc": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/wrtc/-/wrtc-0.4.7.tgz",
-      "integrity": "sha512-P6Hn7VT4lfSH49HxLHcHhDq+aFf/jd9dPY7lDHeFhZ22N3858EKuwm2jmnlPzpsRGEPaoF6XwkcxY5SYnt4f/g==",
-      "bundleDependencies": [
-        "node-pre-gyp"
-      ],
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-pre-gyp": "^0.13.0"
-      },
-      "engines": {
-        "node": "^8.11.2 || >=10.0.0"
-      },
-      "optionalDependencies": {
-        "domexception": "^1.0.1"
-      }
-    },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
@@ -21634,15 +21615,6 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "wrtc": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/wrtc/-/wrtc-0.4.7.tgz",
-      "integrity": "sha512-P6Hn7VT4lfSH49HxLHcHhDq+aFf/jd9dPY7lDHeFhZ22N3858EKuwm2jmnlPzpsRGEPaoF6XwkcxY5SYnt4f/g==",
-      "requires": {
-        "domexception": "^1.0.1",
-        "node-pre-gyp": "^0.13.0"
       }
     },
     "xdg-basedir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libp2p/mplex": "^7.0.0",
         "@libp2p/webrtc-star": "^5.0.3",
         "@libp2p/webrtc-star-signalling-server": "^2.0.5",
-        "@sarcophagus-org/sarcophagus-v2-contracts": "^0.1.0",
+        "@sarcophagus-org/sarcophagus-v2-contracts": "^0.3.0",
         "@types/node": "^18.0.0",
         "chalk": "^5.0.1",
         "columnify": "^1.6.0",
@@ -4371,14 +4371,29 @@
       "dev": true
     },
     "node_modules/@sarcophagus-org/sarcophagus-v2-contracts": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@sarcophagus-org/sarcophagus-v2-contracts/-/sarcophagus-v2-contracts-0.1.0.tgz",
-      "integrity": "sha512-rTMBs9Pm34KyIuSHgaFnfnWKS02DLgXv8NqMUoukMcQf/Z5p/CxVkyLV7uGFU7nye7YCjtsznSpnOFY5a6Dorg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@sarcophagus-org/sarcophagus-v2-contracts/-/sarcophagus-v2-contracts-0.3.0.tgz",
+      "integrity": "sha512-BUHC7UaKGfURVkegGaF+JtG9kkQZO64hECZ0YowkD99S0xBTAIWw7hpAji1zT62u2TUuZU/r2cI6oXECXL9qhA==",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.6.0"
+        "@openzeppelin/contracts": "^4.6.0",
+        "keyv": "^4.5.0",
+        "shamirs-secret-sharing-ts": "^1.0.2"
       },
       "engines": {
         "node": ">=16.15.0"
+      }
+    },
+    "node_modules/@sarcophagus-org/sarcophagus-v2-contracts/node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
+    "node_modules/@sarcophagus-org/sarcophagus-v2-contracts/node_modules/keyv": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/@scure/base": {
@@ -11336,6 +11351,14 @@
         "sha.js": "bin.js"
       }
     },
+    "node_modules/shamirs-secret-sharing-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shamirs-secret-sharing-ts/-/shamirs-secret-sharing-ts-1.0.2.tgz",
+      "integrity": "sha512-ivkVMtPptlg768v6pfqeva5JXsJitAw+vv3+aUPlNTi69fCTD69S+E+gTw0Yz99tuyz9a3eC1oiVC1WT2Kcl/w==",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -15624,11 +15647,28 @@
       }
     },
     "@sarcophagus-org/sarcophagus-v2-contracts": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@sarcophagus-org/sarcophagus-v2-contracts/-/sarcophagus-v2-contracts-0.1.0.tgz",
-      "integrity": "sha512-rTMBs9Pm34KyIuSHgaFnfnWKS02DLgXv8NqMUoukMcQf/Z5p/CxVkyLV7uGFU7nye7YCjtsznSpnOFY5a6Dorg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@sarcophagus-org/sarcophagus-v2-contracts/-/sarcophagus-v2-contracts-0.3.0.tgz",
+      "integrity": "sha512-BUHC7UaKGfURVkegGaF+JtG9kkQZO64hECZ0YowkD99S0xBTAIWw7hpAji1zT62u2TUuZU/r2cI6oXECXL9qhA==",
       "requires": {
-        "@openzeppelin/contracts": "^4.6.0"
+        "@openzeppelin/contracts": "^4.6.0",
+        "keyv": "^4.5.0",
+        "shamirs-secret-sharing-ts": "^1.0.2"
+      },
+      "dependencies": {
+        "json-buffer": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+        },
+        "keyv": {
+          "version": "4.5.2",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+          "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+          "requires": {
+            "json-buffer": "3.0.1"
+          }
+        }
       }
     },
     "@scure/base": {
@@ -20777,6 +20817,14 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "shamirs-secret-sharing-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shamirs-secret-sharing-ts/-/shamirs-secret-sharing-ts-1.0.2.tgz",
+      "integrity": "sha512-ivkVMtPptlg768v6pfqeva5JXsJitAw+vv3+aUPlNTi69fCTD69S+E+gTw0Yz99tuyz9a3eC1oiVC1WT2Kcl/w==",
+      "requires": {
+        "randombytes": "^2.1.0"
       }
     },
     "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@libp2p/mplex": "^7.0.0",
     "@libp2p/webrtc-star": "^5.0.3",
     "@libp2p/webrtc-star-signalling-server": "^2.0.5",
-    "@sarcophagus-org/sarcophagus-v2-contracts": "^0.3.0",
+    "@sarcophagus-org/sarcophagus-v2-contracts": "^0.4.0",
     "@types/node": "^18.0.0",
     "chalk": "^5.0.1",
     "columnify": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "libp2p": "^0.40.0",
     "node-schedule": "^2.1.0",
     "peer-id": "^0.16.0",
-    "prompt-sync": "^4.2.0",
-    "wrtc": "^0.4.7"
+    "prompt-sync": "^4.2.0"
   },
   "devDependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",

--- a/src/models/node-config.ts
+++ b/src/models/node-config.ts
@@ -1,5 +1,5 @@
 import { webRTCStar } from "@libp2p/webrtc-star";
-import wrtc from "wrtc";
+import wrtc from "@koush/wrtc";
 import { kadDHT } from "@libp2p/kad-dht";
 import { noise } from "@chainsafe/libp2p-noise";
 import { mplex } from "@libp2p/mplex";
@@ -22,7 +22,7 @@ const dht = kadDHT({
   clientMode: false,
 });
 
-const webRtcStar = webRTCStar({wrtc});
+const webRtcStar = webRTCStar({ wrtc });
 
 export class NodeConfig {
   public configObj: Libp2pOptions = {


### PR DESCRIPTION
NOTE: Version `0.4.0` of the sarcophagus contracts must be published before this is merged.

`wrtc` was re-added from a merge, which breaks `npm install` on m1 macs. Removed. The existing `@koush/wrtc` fixes this issue.

Also set `sarcophagus-v2-contracts` to `0.4.0`, in anticipation of [this PR merge](https://github.com/sarcophagus-org/sarcophagus-v2-contracts/pull/95/files).