### PR TITLE
Webrtc update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ ETH_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff
 
 ## RPC provider. If running on local network, this env var is not required
 PROVIDER_URL=
+
+## List the domain associated with your archaeologist
+## Required if running your archaeologist on websockets (recommended if not running locally)
+DOMAIN=

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@libp2p/webrtc-star": "^5.0.3",
         "@libp2p/webrtc-star-signalling-server": "^2.0.5",
         "@libp2p/websockets": "^5.0.1",
+        "@mapbox/node-pre-gyp": "^1.0.10",
         "@sarcophagus-org/sarcophagus-v2-contracts": "^0.7.0",
         "@types/node": "^18.0.0",
         "chalk": "^5.0.1",
@@ -3700,6 +3701,39 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
+      "integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@metamask/eth-sig-util": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
@@ -4821,8 +4855,7 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -4893,7 +4926,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -5000,6 +5032,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
     "node_modules/arconnect": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/arconnect/-/arconnect-0.4.2.tgz",
@@ -5007,6 +5044,18 @@
       "dev": true,
       "dependencies": {
         "arweave": "^1.10.13"
+      }
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/arg": {
@@ -5113,8 +5162,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base-x": {
       "version": "3.0.9",
@@ -5285,7 +5333,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5534,6 +5581,14 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -5685,6 +5740,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "bin": {
+        "color-support": "bin.js"
+      }
     },
     "node_modules/columnify": {
       "version": "1.6.0",
@@ -5857,8 +5920,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/configstore": {
       "version": "5.0.1",
@@ -5876,6 +5938,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "node_modules/convert-hrtime": {
       "version": "5.0.0",
@@ -6253,6 +6320,11 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6260,6 +6332,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -6363,8 +6443,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -7059,11 +7138,32 @@
         "node": ">=12"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -7128,6 +7228,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -7187,7 +7306,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7219,7 +7337,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7780,6 +7897,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
     "node_modules/has-yarn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
@@ -7862,7 +7984,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -7952,7 +8073,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -8285,7 +8405,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9411,7 +9530,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -9426,7 +9544,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -9558,6 +9675,51 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
+    "node_modules/minipass": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+      "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mnemonist": {
       "version": "0.38.5",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.5.tgz",
@@ -9678,6 +9840,25 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -9781,6 +9962,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -9824,6 +10019,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -9888,7 +10094,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -10172,7 +10377,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10637,6 +10841,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
@@ -10838,6 +11056,11 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/set-delayed-interval": {
       "version": "1.0.0",
@@ -11101,7 +11324,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11244,6 +11466,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^4.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tdigest": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
@@ -11346,6 +11584,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
@@ -11727,6 +11970,20 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/wherearewe": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
@@ -11789,6 +12046,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "node_modules/widest-line": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
@@ -11841,8 +12106,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -14546,6 +14810,32 @@
         }
       }
     },
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
+      "integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "@metamask/eth-sig-util": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
@@ -15529,8 +15819,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -15589,7 +15878,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -15665,6 +15953,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
     "arconnect": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/arconnect/-/arconnect-0.4.2.tgz",
@@ -15672,6 +15965,15 @@
       "dev": true,
       "requires": {
         "arweave": "^1.10.13"
+      }
+    },
+    "are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
       }
     },
     "arg": {
@@ -15768,8 +16070,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base-x": {
       "version": "3.0.9",
@@ -15898,7 +16199,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -16084,6 +16384,11 @@
         "readdirp": "~3.6.0"
       }
     },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -16195,6 +16500,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "columnify": {
       "version": "1.6.0",
@@ -16332,8 +16642,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "configstore": {
       "version": "5.0.1",
@@ -16348,6 +16657,11 @@
         "write-file-atomic": "^3.0.0",
         "xdg-basedir": "^4.0.0"
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "convert-hrtime": {
       "version": "5.0.0",
@@ -16607,11 +16921,21 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
     "depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true
+    },
+    "detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
     },
     "diff": {
       "version": "5.0.0",
@@ -16705,8 +17029,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -17220,11 +17543,28 @@
         "universalify": "^2.0.0"
       }
     },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "requires": {
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -17266,6 +17606,22 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
+    },
+    "gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "requires": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -17311,7 +17667,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17325,7 +17680,6 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
           "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -17745,6 +18099,11 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
     "has-yarn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
@@ -17815,7 +18174,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -17873,7 +18231,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -18097,8 +18454,7 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-generator-function": {
       "version": "1.0.10",
@@ -18930,7 +19286,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
       "requires": {
         "semver": "^6.0.0"
       },
@@ -18938,8 +19293,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -19043,6 +19397,38 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
+    "minipass": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+      "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
     "mnemonist": {
       "version": "0.38.5",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.5.tgz",
@@ -19128,6 +19514,14 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
     },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -19202,6 +19596,14 @@
         }
       }
     },
+    "nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "requires": {
+        "abbrev": "1"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -19229,6 +19631,17 @@
           "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
           "dev": true
         }
+      }
+    },
+    "npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "requires": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "object-assign": {
@@ -19274,7 +19687,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -19455,8 +19867,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key": {
       "version": "3.1.1",
@@ -19809,6 +20220,14 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
@@ -19960,6 +20379,11 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "set-delayed-interval": {
       "version": "1.0.0",
@@ -20184,7 +20608,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -20283,6 +20706,19 @@
         }
       }
     },
+    "tar": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^4.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      }
+    },
     "tdigest": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
@@ -20360,6 +20796,11 @@
           }
         }
       }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "truncate-utf8-bytes": {
       "version": "1.0.2",
@@ -20649,6 +21090,20 @@
         "defaults": "^1.0.3"
       }
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "wherearewe": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
@@ -20692,6 +21147,14 @@
         "is-typed-array": "^1.1.9"
       }
     },
+    "wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "widest-line": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
@@ -20731,8 +21194,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@libp2p/mplex": "^7.0.0",
         "@libp2p/webrtc-star": "^5.0.3",
         "@libp2p/webrtc-star-signalling-server": "^2.0.5",
-        "@sarcophagus-org/sarcophagus-v2-contracts": "^0.6.0",
+        "@libp2p/websockets": "^5.0.1",
+        "@sarcophagus-org/sarcophagus-v2-contracts": "^0.7.0",
         "@types/node": "^18.0.0",
         "chalk": "^5.0.1",
         "columnify": "^1.6.0",
@@ -112,6 +113,11 @@
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
+      "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
     },
     "node_modules/@chainsafe/libp2p-noise": {
       "version": "10.0.0",
@@ -2727,28 +2733,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/peer-record/node_modules/@libp2p/utils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.2.tgz",
-      "integrity": "sha512-/+mwCEd1o1sko3fYkVfy9pDT3Ks+KszR4Y3fb3M3/UCETDituvqZKHHM4wyTJsFlrFrohbtYlNvWhJ7Pej3X5g==",
-      "dependencies": {
-        "@achingbrain/ip-address": "^8.1.0",
-        "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-peer-store": "^1.2.1",
-        "@libp2p/logger": "^2.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "is-loopback-addr": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "private-ip": "^2.1.1",
-        "uint8arraylist": "^2.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/peer-record/node_modules/@multiformats/multiaddr": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.5.tgz",
@@ -3125,6 +3109,129 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@libp2p/utils": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.3.tgz",
+      "integrity": "sha512-mUR6NuAkbyLslSb70wW/UP2YIRfefdbEmLkVgj+n3wRDCKBPsBc/9+b7RAlJkTqitxwkkwniFTIlapzAe5UKKg==",
+      "dependencies": {
+        "@achingbrain/ip-address": "^8.1.0",
+        "@libp2p/interface-connection": "^3.0.2",
+        "@libp2p/interface-peer-store": "^1.2.1",
+        "@libp2p/logger": "^2.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
+        "abortable-iterator": "^4.0.2",
+        "err-code": "^3.0.1",
+        "is-loopback-addr": "^2.0.1",
+        "it-stream-types": "^1.0.4",
+        "private-ip": "^3.0.0",
+        "uint8arraylist": "^2.3.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/@libp2p/logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.2.tgz",
+      "integrity": "sha512-7XuYoKuce7wTUkVSpll3A/BVlnCVV2kQEfgHtNe8fK8miXCDJFKYm/DhCP1/ZOFs/TrkVt7F/TFJwQ9tlOj3rw==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^1.0.2",
+        "debug": "^4.3.3",
+        "interface-datastore": "^7.0.0",
+        "multiformats": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/@multiformats/multiaddr": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.1.0.tgz",
+      "integrity": "sha512-yXOUhUR4O0zthRZBj66JO3PVpdhijp8TTeKO56bHL2iuOVNz+1f50K8bsqiea2tX5FjPZ2Iqk1DeW42EAY/aWQ==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^10.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/interface-datastore": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.1.tgz",
+      "integrity": "sha512-Arm3PyEdL9kvzUXVPSE8x6YPK5N0MAP9b7au6D9Y91dgWVVLFMGt/W3oiR1mhgT+U82Qc7FcVgW8FBpivOBDAg==",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/interface-store": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.1.tgz",
+      "integrity": "sha512-S5JcwBV+cJorsD0zGKHcBa8A2e578gw9vhZX0QhkV4Xyl4lAMAg5N2GJceUnjCfj/FOKzxTdABzJKPOF2Id8Ig==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/multiformats": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.2.tgz",
+      "integrity": "sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/nanoid": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/private-ip": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.0.tgz",
+      "integrity": "sha512-HkMBs4nMtrP+cvcw0bDi2BAZIGgiKI4Zq8Oc+dMqNBpHS8iGL4+WO/pRtc8Bwnv9rjnV0QwMDwEBymFtqv7Kww==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "ip-regex": "^5.0.0",
+        "ipaddr.js": "^2.0.1",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/uint8arrays": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+      "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+      "dependencies": {
+        "multiformats": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@libp2p/webrtc-peer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@libp2p/webrtc-peer/-/webrtc-peer-2.0.0.tgz",
@@ -3352,28 +3459,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/webrtc-star/node_modules/@libp2p/utils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.2.tgz",
-      "integrity": "sha512-/+mwCEd1o1sko3fYkVfy9pDT3Ks+KszR4Y3fb3M3/UCETDituvqZKHHM4wyTJsFlrFrohbtYlNvWhJ7Pej3X5g==",
-      "dependencies": {
-        "@achingbrain/ip-address": "^8.1.0",
-        "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-peer-store": "^1.2.1",
-        "@libp2p/logger": "^2.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "is-loopback-addr": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "private-ip": "^2.1.1",
-        "uint8arraylist": "^2.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/webrtc-star/node_modules/@multiformats/multiaddr": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.5.tgz",
@@ -3461,6 +3546,149 @@
       }
     },
     "node_modules/@libp2p/webrtc-star/node_modules/uint8arrays": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+      "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+      "dependencies": {
+        "multiformats": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.1.tgz",
+      "integrity": "sha512-cVZQv4oorXnlH/tU/31dwJsyWklkuHA0CUTAXsfNZ1kYmJz3QnOUSJjjehfx2SDqCFJZv1c/1TA3ikSQYkoSKA==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^3.0.2",
+        "@libp2p/interface-transport": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/utils": "^3.0.2",
+        "@multiformats/mafmt": "^11.0.3",
+        "@multiformats/multiaddr": "^11.0.0",
+        "@multiformats/multiaddr-to-uri": "^9.0.2",
+        "abortable-iterator": "^4.0.2",
+        "err-code": "^3.0.1",
+        "it-ws": "^5.0.6",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.0.0",
+        "wherearewe": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@libp2p/interfaces": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.4.tgz",
+      "integrity": "sha512-e8GZAgr72bT2qfDsIVb9lKDA2itLLGfXnaC18VXsToFUd4kCAe6ggUsRFpCBjrX3aWZ16pRiGy4afprOCfgyIg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@libp2p/logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.2.tgz",
+      "integrity": "sha512-7XuYoKuce7wTUkVSpll3A/BVlnCVV2kQEfgHtNe8fK8miXCDJFKYm/DhCP1/ZOFs/TrkVt7F/TFJwQ9tlOj3rw==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^1.0.2",
+        "debug": "^4.3.3",
+        "interface-datastore": "^7.0.0",
+        "multiformats": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@multiformats/multiaddr": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.1.0.tgz",
+      "integrity": "sha512-yXOUhUR4O0zthRZBj66JO3PVpdhijp8TTeKO56bHL2iuOVNz+1f50K8bsqiea2tX5FjPZ2Iqk1DeW42EAY/aWQ==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^10.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/interface-datastore": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.1.tgz",
+      "integrity": "sha512-Arm3PyEdL9kvzUXVPSE8x6YPK5N0MAP9b7au6D9Y91dgWVVLFMGt/W3oiR1mhgT+U82Qc7FcVgW8FBpivOBDAg==",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/interface-store": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.1.tgz",
+      "integrity": "sha512-S5JcwBV+cJorsD0zGKHcBa8A2e578gw9vhZX0QhkV4Xyl4lAMAg5N2GJceUnjCfj/FOKzxTdABzJKPOF2Id8Ig==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/multiformats": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.2.tgz",
+      "integrity": "sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/nanoid": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/p-timeout": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.0.0.tgz",
+      "integrity": "sha512-5iS61MOdUMemWH9CORQRxVXTp9g5K8rPnI9uQpo97aWgsH3vVXKjkIhDi+OgIDmN3Ly9+AZ2fZV01Wut1yzfKA==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/uint8arrays": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
       "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
@@ -3564,6 +3792,56 @@
         "multiformats": "^9.4.5",
         "uint8arrays": "^3.0.0",
         "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.2.tgz",
+      "integrity": "sha512-vrWmfFadmix5Ab9l//oRQdQ7O3J5bGJpJRMSm21bHlQB0XV4xtNU6vMZBVXeu3Su79LgflEp37cjTFE3yKf3Hw==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri/node_modules/@multiformats/multiaddr": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.1.0.tgz",
+      "integrity": "sha512-yXOUhUR4O0zthRZBj66JO3PVpdhijp8TTeKO56bHL2iuOVNz+1f50K8bsqiea2tX5FjPZ2Iqk1DeW42EAY/aWQ==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^10.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri/node_modules/multiformats": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.2.tgz",
+      "integrity": "sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri/node_modules/uint8arrays": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+      "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+      "dependencies": {
+        "multiformats": "^10.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -4138,9 +4416,9 @@
       "dev": true
     },
     "node_modules/@sarcophagus-org/sarcophagus-v2-contracts": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@sarcophagus-org/sarcophagus-v2-contracts/-/sarcophagus-v2-contracts-0.6.0.tgz",
-      "integrity": "sha512-feGrsAYkjpiFTtERAu17Ykobd6SEUiHlOhqkK66x0+8IKS7f0Fitu1aqeIshg2L3BSIy1MoatYC1VPZrEQkbig==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sarcophagus-org/sarcophagus-v2-contracts/-/sarcophagus-v2-contracts-0.7.0.tgz",
+      "integrity": "sha512-UKO/Bx81bMQkRe1yn5FjstZz6E6pR4eznE3LK1ekQc9BI2Zv0RcLQZAbSgiboSkXe0nNqVrmfOlzyX6DJS3YQQ==",
       "engines": {
         "node": ">=16.15.0"
       }
@@ -8336,6 +8614,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/it-all": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
@@ -8560,6 +8846,43 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/it-take/-/it-take-1.0.2.tgz",
       "integrity": "sha512-u7I6qhhxH7pSevcYNaMECtkvZW365ARqAIt9K+xjdK1B2WUDEjQSfETkOCT8bxFq/59LqrN3cMLUtTgmDBaygw=="
+    },
+    "node_modules/it-ws": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-5.0.6.tgz",
+      "integrity": "sha512-TEEJQaGtkxgP/nGVq8dq48nPT85Afu8kwwvtDFLj4rQLWRhZcb26RWdXLdn9qhXkWPiWbK5H7JWBW1Bebj/SuQ==",
+      "dependencies": {
+        "event-iterator": "^2.0.0",
+        "iso-url": "^1.1.2",
+        "it-stream-types": "^1.0.2",
+        "uint8arrays": "^4.0.2",
+        "ws": "^8.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-ws/node_modules/multiformats": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.2.tgz",
+      "integrity": "sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-ws/node_modules/uint8arrays": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+      "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+      "dependencies": {
+        "multiformats": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
@@ -8820,28 +9143,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/libp2p/node_modules/@libp2p/utils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.2.tgz",
-      "integrity": "sha512-/+mwCEd1o1sko3fYkVfy9pDT3Ks+KszR4Y3fb3M3/UCETDituvqZKHHM4wyTJsFlrFrohbtYlNvWhJ7Pej3X5g==",
-      "dependencies": {
-        "@achingbrain/ip-address": "^8.1.0",
-        "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-peer-store": "^1.2.1",
-        "@libp2p/logger": "^2.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "is-loopback-addr": "^2.0.1",
-        "it-stream-types": "^1.0.4",
-        "private-ip": "^2.1.1",
-        "uint8arraylist": "^2.3.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/libp2p/node_modules/@multiformats/multiaddr": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.5.tgz",
@@ -8980,18 +9281,6 @@
       "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
       "dependencies": {
         "multiformats": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/wherearewe": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
-      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
-      "dependencies": {
-        "is-electron": "^2.2.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -11438,6 +11727,18 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/wherearewe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
+      "dependencies": {
+        "is-electron": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11571,6 +11872,26 @@
       },
       "optionalDependencies": {
         "domexception": "^1.0.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xdg-basedir": {
@@ -11736,6 +12057,11 @@
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
       }
+    },
+    "@chainsafe/is-ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
+      "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
     },
     "@chainsafe/libp2p-noise": {
       "version": "10.0.0",
@@ -13547,24 +13873,6 @@
             "multiformats": "^10.0.0"
           }
         },
-        "@libp2p/utils": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.2.tgz",
-          "integrity": "sha512-/+mwCEd1o1sko3fYkVfy9pDT3Ks+KszR4Y3fb3M3/UCETDituvqZKHHM4wyTJsFlrFrohbtYlNvWhJ7Pej3X5g==",
-          "requires": {
-            "@achingbrain/ip-address": "^8.1.0",
-            "@libp2p/interface-connection": "^3.0.2",
-            "@libp2p/interface-peer-store": "^1.2.1",
-            "@libp2p/logger": "^2.0.0",
-            "@multiformats/multiaddr": "^11.0.0",
-            "abortable-iterator": "^4.0.2",
-            "err-code": "^3.0.1",
-            "is-loopback-addr": "^2.0.1",
-            "it-stream-types": "^1.0.4",
-            "private-ip": "^2.1.1",
-            "uint8arraylist": "^2.3.2"
-          }
-        },
         "@multiformats/multiaddr": {
           "version": "11.0.5",
           "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.5.tgz",
@@ -13827,6 +14135,94 @@
         "@libp2p/interface-metrics": "^3.0.0"
       }
     },
+    "@libp2p/utils": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.3.tgz",
+      "integrity": "sha512-mUR6NuAkbyLslSb70wW/UP2YIRfefdbEmLkVgj+n3wRDCKBPsBc/9+b7RAlJkTqitxwkkwniFTIlapzAe5UKKg==",
+      "requires": {
+        "@achingbrain/ip-address": "^8.1.0",
+        "@libp2p/interface-connection": "^3.0.2",
+        "@libp2p/interface-peer-store": "^1.2.1",
+        "@libp2p/logger": "^2.0.0",
+        "@multiformats/multiaddr": "^11.0.0",
+        "abortable-iterator": "^4.0.2",
+        "err-code": "^3.0.1",
+        "is-loopback-addr": "^2.0.1",
+        "it-stream-types": "^1.0.4",
+        "private-ip": "^3.0.0",
+        "uint8arraylist": "^2.3.2"
+      },
+      "dependencies": {
+        "@libp2p/logger": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.2.tgz",
+          "integrity": "sha512-7XuYoKuce7wTUkVSpll3A/BVlnCVV2kQEfgHtNe8fK8miXCDJFKYm/DhCP1/ZOFs/TrkVt7F/TFJwQ9tlOj3rw==",
+          "requires": {
+            "@libp2p/interface-peer-id": "^1.0.2",
+            "debug": "^4.3.3",
+            "interface-datastore": "^7.0.0",
+            "multiformats": "^10.0.0"
+          }
+        },
+        "@multiformats/multiaddr": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.1.0.tgz",
+          "integrity": "sha512-yXOUhUR4O0zthRZBj66JO3PVpdhijp8TTeKO56bHL2iuOVNz+1f50K8bsqiea2tX5FjPZ2Iqk1DeW42EAY/aWQ==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^10.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "interface-datastore": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.1.tgz",
+          "integrity": "sha512-Arm3PyEdL9kvzUXVPSE8x6YPK5N0MAP9b7au6D9Y91dgWVVLFMGt/W3oiR1mhgT+U82Qc7FcVgW8FBpivOBDAg==",
+          "requires": {
+            "interface-store": "^3.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.1.tgz",
+          "integrity": "sha512-S5JcwBV+cJorsD0zGKHcBa8A2e578gw9vhZX0QhkV4Xyl4lAMAg5N2GJceUnjCfj/FOKzxTdABzJKPOF2Id8Ig=="
+        },
+        "multiformats": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.2.tgz",
+          "integrity": "sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A=="
+        },
+        "nanoid": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+          "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
+        },
+        "private-ip": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.0.tgz",
+          "integrity": "sha512-HkMBs4nMtrP+cvcw0bDi2BAZIGgiKI4Zq8Oc+dMqNBpHS8iGL4+WO/pRtc8Bwnv9rjnV0QwMDwEBymFtqv7Kww==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "ip-regex": "^5.0.0",
+            "ipaddr.js": "^2.0.1",
+            "netmask": "^2.0.2"
+          }
+        },
+        "uint8arrays": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+          "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+          "requires": {
+            "multiformats": "^10.0.0"
+          }
+        }
+      }
+    },
     "@libp2p/webrtc-peer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@libp2p/webrtc-peer/-/webrtc-peer-2.0.0.tgz",
@@ -13908,24 +14304,6 @@
             "debug": "^4.3.3",
             "interface-datastore": "^7.0.0",
             "multiformats": "^10.0.0"
-          }
-        },
-        "@libp2p/utils": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.2.tgz",
-          "integrity": "sha512-/+mwCEd1o1sko3fYkVfy9pDT3Ks+KszR4Y3fb3M3/UCETDituvqZKHHM4wyTJsFlrFrohbtYlNvWhJ7Pej3X5g==",
-          "requires": {
-            "@achingbrain/ip-address": "^8.1.0",
-            "@libp2p/interface-connection": "^3.0.2",
-            "@libp2p/interface-peer-store": "^1.2.1",
-            "@libp2p/logger": "^2.0.0",
-            "@multiformats/multiaddr": "^11.0.0",
-            "abortable-iterator": "^4.0.2",
-            "err-code": "^3.0.1",
-            "is-loopback-addr": "^2.0.1",
-            "it-stream-types": "^1.0.4",
-            "private-ip": "^2.1.1",
-            "uint8arraylist": "^2.3.2"
           }
         },
         "@multiformats/multiaddr": {
@@ -14073,6 +14451,101 @@
         }
       }
     },
+    "@libp2p/websockets": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.1.tgz",
+      "integrity": "sha512-cVZQv4oorXnlH/tU/31dwJsyWklkuHA0CUTAXsfNZ1kYmJz3QnOUSJjjehfx2SDqCFJZv1c/1TA3ikSQYkoSKA==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.2",
+        "@libp2p/interface-transport": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/utils": "^3.0.2",
+        "@multiformats/mafmt": "^11.0.3",
+        "@multiformats/multiaddr": "^11.0.0",
+        "@multiformats/multiaddr-to-uri": "^9.0.2",
+        "abortable-iterator": "^4.0.2",
+        "err-code": "^3.0.1",
+        "it-ws": "^5.0.6",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.0.0",
+        "wherearewe": "^2.0.1"
+      },
+      "dependencies": {
+        "@libp2p/interfaces": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.0.4.tgz",
+          "integrity": "sha512-e8GZAgr72bT2qfDsIVb9lKDA2itLLGfXnaC18VXsToFUd4kCAe6ggUsRFpCBjrX3aWZ16pRiGy4afprOCfgyIg=="
+        },
+        "@libp2p/logger": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.2.tgz",
+          "integrity": "sha512-7XuYoKuce7wTUkVSpll3A/BVlnCVV2kQEfgHtNe8fK8miXCDJFKYm/DhCP1/ZOFs/TrkVt7F/TFJwQ9tlOj3rw==",
+          "requires": {
+            "@libp2p/interface-peer-id": "^1.0.2",
+            "debug": "^4.3.3",
+            "interface-datastore": "^7.0.0",
+            "multiformats": "^10.0.0"
+          }
+        },
+        "@multiformats/multiaddr": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.1.0.tgz",
+          "integrity": "sha512-yXOUhUR4O0zthRZBj66JO3PVpdhijp8TTeKO56bHL2iuOVNz+1f50K8bsqiea2tX5FjPZ2Iqk1DeW42EAY/aWQ==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^10.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "interface-datastore": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.1.tgz",
+          "integrity": "sha512-Arm3PyEdL9kvzUXVPSE8x6YPK5N0MAP9b7au6D9Y91dgWVVLFMGt/W3oiR1mhgT+U82Qc7FcVgW8FBpivOBDAg==",
+          "requires": {
+            "interface-store": "^3.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.1.tgz",
+          "integrity": "sha512-S5JcwBV+cJorsD0zGKHcBa8A2e578gw9vhZX0QhkV4Xyl4lAMAg5N2GJceUnjCfj/FOKzxTdABzJKPOF2Id8Ig=="
+        },
+        "multiformats": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.2.tgz",
+          "integrity": "sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A=="
+        },
+        "nanoid": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+          "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
+        },
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        },
+        "p-timeout": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.0.0.tgz",
+          "integrity": "sha512-5iS61MOdUMemWH9CORQRxVXTp9g5K8rPnI9uQpo97aWgsH3vVXKjkIhDi+OgIDmN3Ly9+AZ2fZV01Wut1yzfKA=="
+        },
+        "uint8arrays": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+          "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+          "requires": {
+            "multiformats": "^10.0.0"
+          }
+        }
+      }
+    },
     "@metamask/eth-sig-util": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
@@ -14142,6 +14615,42 @@
         "multiformats": "^9.4.5",
         "uint8arrays": "^3.0.0",
         "varint": "^6.0.0"
+      }
+    },
+    "@multiformats/multiaddr-to-uri": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.2.tgz",
+      "integrity": "sha512-vrWmfFadmix5Ab9l//oRQdQ7O3J5bGJpJRMSm21bHlQB0XV4xtNU6vMZBVXeu3Su79LgflEp37cjTFE3yKf3Hw==",
+      "requires": {
+        "@multiformats/multiaddr": "^11.0.0"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.1.0.tgz",
+          "integrity": "sha512-yXOUhUR4O0zthRZBj66JO3PVpdhijp8TTeKO56bHL2iuOVNz+1f50K8bsqiea2tX5FjPZ2Iqk1DeW42EAY/aWQ==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^10.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "multiformats": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.2.tgz",
+          "integrity": "sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A=="
+        },
+        "uint8arrays": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+          "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+          "requires": {
+            "multiformats": "^10.0.0"
+          }
+        }
       }
     },
     "@noble/ed25519": {
@@ -14663,9 +15172,9 @@
       }
     },
     "@sarcophagus-org/sarcophagus-v2-contracts": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@sarcophagus-org/sarcophagus-v2-contracts/-/sarcophagus-v2-contracts-0.6.0.tgz",
-      "integrity": "sha512-feGrsAYkjpiFTtERAu17Ykobd6SEUiHlOhqkK66x0+8IKS7f0Fitu1aqeIshg2L3BSIy1MoatYC1VPZrEQkbig=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sarcophagus-org/sarcophagus-v2-contracts/-/sarcophagus-v2-contracts-0.7.0.tgz",
+      "integrity": "sha512-UKO/Bx81bMQkRe1yn5FjstZz6E6pR4eznE3LK1ekQc9BI2Zv0RcLQZAbSgiboSkXe0nNqVrmfOlzyX6DJS3YQQ=="
     },
     "@scure/base": {
       "version": "1.1.1",
@@ -17797,6 +18306,11 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
+    },
     "it-all": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
@@ -17979,6 +18493,33 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/it-take/-/it-take-1.0.2.tgz",
       "integrity": "sha512-u7I6qhhxH7pSevcYNaMECtkvZW365ARqAIt9K+xjdK1B2WUDEjQSfETkOCT8bxFq/59LqrN3cMLUtTgmDBaygw=="
+    },
+    "it-ws": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-5.0.6.tgz",
+      "integrity": "sha512-TEEJQaGtkxgP/nGVq8dq48nPT85Afu8kwwvtDFLj4rQLWRhZcb26RWdXLdn9qhXkWPiWbK5H7JWBW1Bebj/SuQ==",
+      "requires": {
+        "event-iterator": "^2.0.0",
+        "iso-url": "^1.1.2",
+        "it-stream-types": "^1.0.2",
+        "uint8arrays": "^4.0.2",
+        "ws": "^8.4.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.2.tgz",
+          "integrity": "sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A=="
+        },
+        "uint8arrays": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+          "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+          "requires": {
+            "multiformats": "^10.0.0"
+          }
+        }
+      }
     },
     "js-sha3": {
       "version": "0.8.0",
@@ -18186,24 +18727,6 @@
             "multiformats": "^10.0.0"
           }
         },
-        "@libp2p/utils": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.2.tgz",
-          "integrity": "sha512-/+mwCEd1o1sko3fYkVfy9pDT3Ks+KszR4Y3fb3M3/UCETDituvqZKHHM4wyTJsFlrFrohbtYlNvWhJ7Pej3X5g==",
-          "requires": {
-            "@achingbrain/ip-address": "^8.1.0",
-            "@libp2p/interface-connection": "^3.0.2",
-            "@libp2p/interface-peer-store": "^1.2.1",
-            "@libp2p/logger": "^2.0.0",
-            "@multiformats/multiaddr": "^11.0.0",
-            "abortable-iterator": "^4.0.2",
-            "err-code": "^3.0.1",
-            "is-loopback-addr": "^2.0.1",
-            "it-stream-types": "^1.0.4",
-            "private-ip": "^2.1.1",
-            "uint8arraylist": "^2.3.2"
-          }
-        },
         "@multiformats/multiaddr": {
           "version": "11.0.5",
           "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.0.5.tgz",
@@ -18290,14 +18813,6 @@
           "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
           "requires": {
             "multiformats": "^10.0.0"
-          }
-        },
-        "wherearewe": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
-          "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
-          "requires": {
-            "is-electron": "^2.2.0"
           }
         }
       }
@@ -20134,6 +20649,14 @@
         "defaults": "^1.0.3"
       }
     },
+    "wherearewe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
+      "requires": {
+        "is-electron": "^2.2.0"
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -20231,6 +20754,12 @@
         "domexception": "^1.0.1",
         "node-pre-gyp": "^0.13.0"
       }
+    },
+    "ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@libp2p/webrtc-star": "^5.0.3",
     "@libp2p/webrtc-star-signalling-server": "^2.0.5",
     "@libp2p/websockets": "^5.0.1",
+    "@mapbox/node-pre-gyp": "^1.0.10",
     "@sarcophagus-org/sarcophagus-v2-contracts": "^0.7.0",
     "@types/node": "^18.0.0",
     "chalk": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@libp2p/mplex": "^7.0.0",
     "@libp2p/webrtc-star": "^5.0.3",
     "@libp2p/webrtc-star-signalling-server": "^2.0.5",
+    "@libp2p/websockets": "^5.0.1",
     "@sarcophagus-org/sarcophagus-v2-contracts": "^0.7.0",
     "@types/node": "^18.0.0",
     "chalk": "^5.0.1",

--- a/src/cli/config/profile-args.ts
+++ b/src/cli/config/profile-args.ts
@@ -27,4 +27,11 @@ export const profileOptionDefinitions = [
     description:
       "How much free bond you would like to deposit when registering. You can add more free bond later in a separate transaction. Free bond is locked up when you accept curses, and returned after a successful unwrapping.",
   },
+  {
+    name: "domain",
+    alias: "w",
+    type: parseEther,
+    description:
+      "If registering with a domain, this will be used in place of your peerID",
+  },
 ];

--- a/src/cli/config/profile-args.ts
+++ b/src/cli/config/profile-args.ts
@@ -26,12 +26,5 @@ export const profileOptionDefinitions = [
     type: parseEther,
     description:
       "How much free bond you would like to deposit when registering. You can add more free bond later in a separate transaction. Free bond is locked up when you accept curses, and returned after a successful unwrapping.",
-  },
-  {
-    name: "domain",
-    alias: "w",
-    type: parseEther,
-    description:
-      "If registering with a domain, this will be used in place of your peerID",
-  },
+  }
 ];

--- a/src/cli/prompts/register-prompt.ts
+++ b/src/cli/prompts/register-prompt.ts
@@ -30,6 +30,7 @@ const confirmReviewQuestion = (diggingFee: string, rewrapInterval: string, freeB
       `Digging Fee: ${diggingFee} SARCO\n` +
       `Free Bond: ${freeBond} SARCO\n` +
       `Maximum Rewrap Interval: ${rewrapInterval}\n\n` +
+      `PeerId: ${process.env.DOMAIN}\n\n` +
       "Do you want to continue?",
     default: true,
   },

--- a/src/cli/prompts/register-prompt.ts
+++ b/src/cli/prompts/register-prompt.ts
@@ -30,7 +30,7 @@ const confirmReviewQuestion = (diggingFee: string, rewrapInterval: string, freeB
       `Digging Fee: ${diggingFee} SARCO\n` +
       `Free Bond: ${freeBond} SARCO\n` +
       `Maximum Rewrap Interval: ${rewrapInterval}\n\n` +
-      `PeerId: ${process.env.DOMAIN}\n\n` +
+      `Domain: ${process.env.DOMAIN}\n\n` +
       "Do you want to continue?",
     default: true,
   },

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -5,7 +5,9 @@ import { logCallout } from "../logger/formatter";
 import { archLogger } from "../logger/chalk-theme";
 import { formatEther } from "ethers/lib/utils";
 import { exit } from "process";
-import { BigNumber, ethers } from "ethers";
+import { BigNumber } from "ethers";
+import jsonfile from "jsonfile";
+import { FILE_READ_EXCEPTION } from "../utils/exit-codes";
 
 const PEER_ID_DELIMITER = ":";
 
@@ -109,4 +111,15 @@ export const formatFullPeerString = (peerId: string, domain?: string): string =>
   return domain ?
     domain + PEER_ID_DELIMITER + peerId :
     peerId;
+}
+
+export async function loadPeerIdJsonFromFileOrExit(): Promise<Record<string, string>> {
+  const peerIdFile = "./peer-id.json";
+
+  try {
+    return jsonfile.readFile(peerIdFile);
+  } catch (e) {
+    archLogger.error(`Error reading file: ${e}`);
+    exit(FILE_READ_EXCEPTION);
+  }
 }

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -7,6 +7,8 @@ import { formatEther } from "ethers/lib/utils";
 import { exit } from "process";
 import { BigNumber, ethers } from "ethers";
 
+const PEER_ID_DELIMITER = ":";
+
 export const handleCommandArgs = (
   optionDefinitions: any,
   options: any,
@@ -102,3 +104,9 @@ export const randomIntFromInterval = (min, max) => {
   // min and max included
   return Math.floor(Math.random() * (max - min + 1) + min);
 };
+
+export const formatFullPeerString = (peerId: string, domain?: string): string => {
+  return domain ?
+    domain + PEER_ID_DELIMITER + peerId :
+    peerId;
+}

--- a/src/models/archaeologist.ts
+++ b/src/models/archaeologist.ts
@@ -1,5 +1,4 @@
 import { Libp2p } from "libp2p";
-import { loadPeerIdFromFile } from "../utils";
 import { genListenAddresses } from "../utils/listen-addresses";
 import { createAndStartNode } from "../utils/create-and-start-node";
 import { NodeConfig } from "./node-config";
@@ -73,7 +72,12 @@ export class Archaeologist {
   async initNode(arg: { config: PublicEnvConfig; web3Interface: Web3Interface }) {
     if (this.listenAddressesConfig) {
       const { signalServerList } = this.listenAddressesConfig!;
-      this.listenAddresses = genListenAddresses(signalServerList, this.peerId.toJSON().id);
+      this.listenAddresses = genListenAddresses(
+        signalServerList,
+        this.peerId.toJSON().id,
+        false,
+        process.env.DOMAIN
+      );
     }
 
     this.nodeConfig.add("peerId", this.peerId);

--- a/src/models/node-config.ts
+++ b/src/models/node-config.ts
@@ -5,6 +5,7 @@ import { noise } from "@chainsafe/libp2p-noise";
 import { mplex } from "@libp2p/mplex";
 import { bootstrap } from "@libp2p/bootstrap";
 import { Libp2pOptions } from "libp2p";
+import { webSockets } from '@libp2p/websockets';
 
 interface NodeConfigParams {
   bootstrapList?: string[];
@@ -17,6 +18,7 @@ export const PUBLIC_KEY_STREAM = "/archaeologist-public-key";
 export const NEGOTIATION_SIGNATURE_STREAM = "/archaeologist-negotiation-signature";
 export const SIGNAL_SERVER_LIST = ["sig.encryptafile.com"];
 const DHT_PROTOCOL_PREFIX = "/archaeologist-service";
+const domain = process.env.DOMAIN;
 
 const dht = kadDHT({
   protocolPrefix: DHT_PROTOCOL_PREFIX,
@@ -27,17 +29,25 @@ const webRtcStar = webRTCStar({ wrtc });
 
 export class NodeConfig {
   public configObj: Libp2pOptions = {
-    transports: [webRtcStar.transport],
+    transports: [
+      domain ? webSockets() : webRtcStar.transport
+    ],
     connectionEncryption: [noise()],
     streamMuxers: [mplex()],
     dht,
-    peerDiscovery: [webRtcStar.discovery],
+    peerDiscovery: [
+      webRtcStar.discovery
+    ],
     connectionManager: {
       autoDial: false,
     },
   };
 
   constructor(options: NodeConfigParams = {}) {
+    if (!domain) {
+      this.configObj.peerDiscovery!.push(webRtcStar.discovery)
+    }
+
     if (options.bootstrapList) {
       this.configObj.peerDiscovery!.push(
         bootstrap({

--- a/src/scripts/profile-setup.ts
+++ b/src/scripts/profile-setup.ts
@@ -3,12 +3,11 @@ import "dotenv/config";
 import { getWeb3Interface } from "./web3-interface";
 import { validateEnvVars } from "../utils/validateEnv";
 import { exit } from "process";
-import { FILE_READ_EXCEPTION, RPC_EXCEPTION } from "../utils/exit-codes";
+import { RPC_EXCEPTION } from "../utils/exit-codes";
 import { archLogger } from "../logger/chalk-theme";
 import { BigNumber, ethers } from "ethers";
 import { requestApproval } from "./approve_utils";
 
-import jsonfile from "jsonfile";
 import { getOnchainProfile, inMemoryStore } from "../utils/onchain-data";
 import { formatFullPeerString, loadPeerIdJsonFromFileOrExit, logProfile } from "../cli/utils";
 

--- a/src/scripts/profile-setup.ts
+++ b/src/scripts/profile-setup.ts
@@ -25,7 +25,6 @@ export interface ProfileParams {
   rewrapInterval?: number;
   freeBond?: BigNumber;
   peerId?: string;
-  domain?: string;
 }
 
 const web3Interface = await getWeb3Interface();
@@ -36,7 +35,9 @@ export async function profileSetup(
   exitAfterTx: boolean = true,
   skipApproval?: boolean
 ) {
-  const { diggingFee, rewrapInterval, freeBond, peerId, domain } = args;
+  const { diggingFee, rewrapInterval, freeBond, peerId } = args;
+  const domain = process.env.DOMAIN;
+
   let freeBondDeposit = ethers.constants.Zero;
 
   if (freeBond && freeBond.gt(ethers.constants.Zero)) {
@@ -68,7 +69,7 @@ export async function profileSetup(
 
   try {
     const txType = isUpdate ? "Updating" : "Registering";
-
+    console.log("domain", domain);
     const tx = isUpdate
       ? await web3Interface.archaeologistFacet.updateArchaeologist(
           domain || peerId || peerIdJson.id,

--- a/src/scripts/profile-setup.ts
+++ b/src/scripts/profile-setup.ts
@@ -25,6 +25,7 @@ export interface ProfileParams {
   rewrapInterval?: number;
   freeBond?: BigNumber;
   peerId?: string;
+  domain?: string;
 }
 
 const web3Interface = await getWeb3Interface();
@@ -35,7 +36,7 @@ export async function profileSetup(
   exitAfterTx: boolean = true,
   skipApproval?: boolean
 ) {
-  const { diggingFee, rewrapInterval, freeBond, peerId } = args;
+  const { diggingFee, rewrapInterval, freeBond, peerId, domain } = args;
   let freeBondDeposit = ethers.constants.Zero;
 
   if (freeBond && freeBond.gt(ethers.constants.Zero)) {
@@ -70,13 +71,13 @@ export async function profileSetup(
 
     const tx = isUpdate
       ? await web3Interface.archaeologistFacet.updateArchaeologist(
-          peerId || peerIdJson.id,
+          domain || peerId || peerIdJson.id,
           diggingFee,
           rewrapInterval,
           freeBondDeposit
         )
       : await web3Interface.archaeologistFacet.registerArchaeologist(
-          peerId || peerIdJson.id,
+          domain || peerId || peerIdJson.id,
           diggingFee,
           rewrapInterval,
           freeBondDeposit

--- a/src/scripts/profile-setup.ts
+++ b/src/scripts/profile-setup.ts
@@ -10,7 +10,7 @@ import { requestApproval } from "./approve_utils";
 
 import jsonfile from "jsonfile";
 import { getOnchainProfile, inMemoryStore } from "../utils/onchain-data";
-import { formatFullPeerString, logProfile } from "../cli/utils";
+import { formatFullPeerString, loadPeerIdJsonFromFileOrExit, logProfile } from "../cli/utils";
 
 validateEnvVars();
 
@@ -58,18 +58,10 @@ export async function profileSetup(
   }
 
   const domain = process.env.DOMAIN;
-  let peerIdJson;
-
-  try {
-    peerIdJson = await jsonfile.readFile("./peer-id.json");
-  } catch (e) {
-    archLogger.error(`Error reading file: ${e}`);
-    exit(FILE_READ_EXCEPTION);
-  }
-
+  let peerIdJson = await loadPeerIdJsonFromFileOrExit();
   const pId = peerId || peerIdJson.id;
 
-  // If using websockets with a domain, use a delimeter
+  // If using websockets with a domain, use a delimiter
   // to store domain + peerId on the contracts
   const fullPeerString = formatFullPeerString(pId, domain);
 

--- a/src/utils/health-check.ts
+++ b/src/utils/health-check.ts
@@ -34,7 +34,7 @@ export async function healthCheck(web3Interface: Web3Interface, peerId?: string)
 
     // Validate local peerId matches the one on the profile
     if (peerId) {
-      if (peerId !== profile.peerId && peerId !== formatFullPeerString(peerId, process.env.DOMAIN)) {
+      if (peerId !== profile.peerId && peerId !== formatFullPeerString(profile.peerId, process.env.DOMAIN)) {
         logCallout(async () => {
           archLogger.warn("Peer ID on profile does not match local Peer Id\n");
           archLogger.warn("Please update your profile \n");

--- a/src/utils/health-check.ts
+++ b/src/utils/health-check.ts
@@ -12,7 +12,7 @@ import {
   inMemoryStore,
   OnchainProfile,
 } from "./onchain-data";
-import { logBalances, logProfile } from "../cli/utils";
+import { formatFullPeerString, logBalances, logProfile } from "../cli/utils";
 import { registerPrompt } from "../cli/prompts/register-prompt";
 
 /**
@@ -34,14 +34,15 @@ export async function healthCheck(web3Interface: Web3Interface, peerId?: string)
 
     // Validate local peerId matches the one on the profile
     if (peerId) {
-      if (peerId !== profile.peerId) {
+      if (peerId !== profile.peerId && peerId !== formatFullPeerString(peerId, process.env.DOMAIN)) {
         logCallout(async () => {
           archLogger.warn("Peer ID on profile does not match local Peer Id\n");
+          archLogger.warn("Please update your profile \n");
           archLogger.warn("Your archaeologist will not appear in the embalmer webapp\n");
         });
 
         // TODO -- add notification once notifications are setup
-        // TODO -- consider prompting user to update their profile
+        // TODO -- consider quitting and forcing user to update their profile
       }
     }
 

--- a/src/utils/listen-addresses.ts
+++ b/src/utils/listen-addresses.ts
@@ -1,4 +1,5 @@
 import { getLocalStarSignallingPort } from "../scripts/run_local/helpers";
+import { archLogger } from "../logger/chalk-theme";
 
 export const genListenAddresses = (
   servers: string[],
@@ -7,14 +8,12 @@ export const genListenAddresses = (
   domain?: string
 ): string[] => {
   return domain ?
-    wssListenAddress(domain) :
+    wssListenAddress() :
     ssListenAddresses(isLocal === true, servers, peerId);
 };
 
-export const wssListenAddress = (
-  domain: string
-): string[] => {
-  console.log("listening on websocket")
+export const wssListenAddress = (): string[] => {
+  archLogger.info("using websockets")
   return [`/ip4/127.0.0.1/tcp/9000/wss`]
 };
 
@@ -23,7 +22,7 @@ export const ssListenAddresses = (
   servers: string[],
   peerId?: string
 ): string[] => {
-  console.log("listening on sig server");
+  archLogger.info("using signalling server");
   return servers.map(server => {
     const ssAddress = isLocal
       ? `/ip4/${server}/tcp/${getLocalStarSignallingPort()}/ws/p2p-webrtc-star`

--- a/src/utils/listen-addresses.ts
+++ b/src/utils/listen-addresses.ts
@@ -3,9 +3,18 @@ import { getLocalStarSignallingPort } from "../scripts/run_local/helpers";
 export const genListenAddresses = (
   servers: string[],
   peerId?: string,
-  isLocal?: boolean
+  isLocal?: boolean,
+  domain?: string
 ): string[] => {
-  return ssListenAddresses(isLocal === true, servers, peerId);
+  return domain ?
+    wssListenAddress(domain) :
+    ssListenAddresses(isLocal === true, servers, peerId);
+};
+
+export const wssListenAddress = (
+  domain: string
+): string[] => {
+  return [`/dns4/${domain}/tcp/443/wss`]
 };
 
 export const ssListenAddresses = (

--- a/src/utils/listen-addresses.ts
+++ b/src/utils/listen-addresses.ts
@@ -7,15 +7,15 @@ export const genListenAddresses = (
   domain?: string
 ): string[] => {
   return domain ?
-    wssListenAddress(peerId) :
+    wssListenAddress(domain) :
     ssListenAddresses(isLocal === true, servers, peerId);
 };
 
 export const wssListenAddress = (
-  peerId?: string
+  domain: string
 ): string[] => {
   console.log("listening on websocket")
-  return [`/ip4/127.0.0.1/tcp/9000/wss/p2p/${peerId}`]
+  return [`/ip4/127.0.0.1/tcp/9000/wss`]
 };
 
 export const ssListenAddresses = (

--- a/src/utils/listen-addresses.ts
+++ b/src/utils/listen-addresses.ts
@@ -14,7 +14,7 @@ export const genListenAddresses = (
 export const wssListenAddress = (
   domain: string
 ): string[] => {
-  return [`/dns4/${domain}/tcp/443/wss`]
+  return [`/ip4/127.0.0.1/tcp/9000/wss`]
 };
 
 export const ssListenAddresses = (

--- a/src/utils/listen-addresses.ts
+++ b/src/utils/listen-addresses.ts
@@ -7,15 +7,15 @@ export const genListenAddresses = (
   domain?: string
 ): string[] => {
   return domain ?
-    wssListenAddress(domain) :
+    wssListenAddress(peerId) :
     ssListenAddresses(isLocal === true, servers, peerId);
 };
 
 export const wssListenAddress = (
-  domain: string
+  peerId?: string
 ): string[] => {
   console.log("listening on websocket")
-  return [`/ip4/127.0.0.1/tcp/9000/wss`]
+  return [`/ip4/127.0.0.1/tcp/9000/wss/p2p/${peerId}`]
 };
 
 export const ssListenAddresses = (

--- a/src/utils/listen-addresses.ts
+++ b/src/utils/listen-addresses.ts
@@ -14,6 +14,7 @@ export const genListenAddresses = (
 export const wssListenAddress = (
   domain: string
 ): string[] => {
+  console.log("listening on websocket")
   return [`/ip4/127.0.0.1/tcp/9000/wss`]
 };
 
@@ -22,6 +23,7 @@ export const ssListenAddresses = (
   servers: string[],
   peerId?: string
 ): string[] => {
+  console.log("listening on sig server");
   return servers.map(server => {
     const ssAddress = isLocal
       ? `/ip4/${server}/tcp/${getLocalStarSignallingPort()}/ws/p2p-webrtc-star`


### PR DESCRIPTION
Add websockets support to the arch service -- backwards compatible so will still work with the signalling server as well.

## Notes
1. Adds a `DOMAIN` to the .env. If this value is set, the arch service will use websockets. Otherwise it uses signalling server.
2. When registering/updating, uses a delimiter for the profile peerID if the domain exists: `<domain>:<peerId>`


## TODO
The webapp will need an update to handle the new peer ID delimiter when the domain exists.
Add domain validation when parsing the env var, and potentially store on arch model.
Need to determine best way to do peer discovery, as using websockets means peer discovery is turned off currently.