### PR TITLE
dont validate update args if they are undefined

### DIFF
--- a/src/cli/shared/profile-validations.ts
+++ b/src/cli/shared/profile-validations.ts
@@ -6,16 +6,20 @@ import { BigNumber } from "ethers";
 const MINIMUM_REWRAP_INTERVAL = 15 * 60; // 15 minutes
 const MINIMUM_MAX_RESURRECTION_TIME_INTERVAL = 60 * 60 * 24; // 1 day
 
+// rewrapInterval can be undefined if it isn't included in an update profile call
+// in this case, the interval already on the profile will be used
 export const validateRewrapInterval = (rewrapInterval: number | undefined) => {
-  if ((rewrapInterval ?? 0) < MINIMUM_REWRAP_INTERVAL) {
+  if (rewrapInterval && rewrapInterval < MINIMUM_REWRAP_INTERVAL) {
     logValidationErrorAndExit(
       `The rewrap interval must be at least: ${MINIMUM_REWRAP_INTERVAL} seconds`
     );
   }
 };
 
+// maximumResurrectionTime can be undefined if it isn't included in an update profile call
+// in this case, the interval already on the profile will be used
 export const validateMaxResurrectionTime = (maximumResurrectionTime: number | undefined) => {
-  if ((maximumResurrectionTime ?? 0) < MINIMUM_MAX_RESURRECTION_TIME_INTERVAL) {
+  if (maximumResurrectionTime && maximumResurrectionTime < MINIMUM_MAX_RESURRECTION_TIME_INTERVAL) {
     logValidationErrorAndExit(
       `The maximum resurrection time must be at least: ${MINIMUM_REWRAP_INTERVAL} seconds into the future`
     );

--- a/src/cli/shared/profile-validations.ts
+++ b/src/cli/shared/profile-validations.ts
@@ -17,7 +17,7 @@ export const validateRewrapInterval = (rewrapInterval: number | undefined) => {
 };
 
 // maximumResurrectionTime can be undefined if it isn't included in an update profile call
-// in this case, the interval already on the profile will be used
+// in this case, the max res time already on the profile will be used
 export const validateMaxResurrectionTime = (maximumResurrectionTime: number | undefined) => {
   if (maximumResurrectionTime && maximumResurrectionTime < MINIMUM_MAX_RESURRECTION_TIME_INTERVAL) {
     logValidationErrorAndExit(


### PR DESCRIPTION
Skip validating max rewrap interval or max resurrection time if they aren't included in the update args.