### PR TITLE
Sarco ID Cache Bugfix

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,32 @@
+name: Build and Push Docker Image
+on:
+  push:
+    branches:
+      develop
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish-hello-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout respository
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push docker image
+        run: |
+          docker build . --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev

--- a/src/cli/prompts/register-prompt.ts
+++ b/src/cli/prompts/register-prompt.ts
@@ -5,7 +5,7 @@ import { hasAllowance, requestApproval } from "../../scripts/approve_utils";
 import { logColors } from "../../logger/chalk-theme";
 import { runApprove } from "../../utils/blockchain/approve";
 import { ONE_MONTH_IN_SECONDS } from "../utils";
-import { getBlockTimestampMs } from "../../utils/blockchain/helpers";
+import { getBlockTimestamp } from "../../utils/blockchain/helpers";
 
 const DEFAULT_DIGGING_FEES_MONTHLY = "5";
 
@@ -208,7 +208,7 @@ const parseMaxResTimeAnswer = async (maxResTime: string | number): Promise<numbe
     maxResurrectionTimeInterval = maxResTime * ONE_MONTH_IN_SECONDS;
   }
 
-  return Math.trunc((await getBlockTimestampMs()) / 1000) + maxResurrectionTimeInterval;
+  return Math.trunc((await getBlockTimestamp())) + maxResurrectionTimeInterval;
 };
 
 //

--- a/src/logger/chalk-theme.ts
+++ b/src/logger/chalk-theme.ts
@@ -7,6 +7,10 @@ export const logColors = {
   green: chalk.green,
 };
 
+const log = (msg: string) => {
+  console.log(`${Date.now() / 1000}: ${msg}`);
+}
+
 export const archLogger = {
   debug: msg => {
     if (process.env.DEBUG) {
@@ -14,8 +18,8 @@ export const archLogger = {
       console.log(debugLog);
     }
   },
-  info: msg => console.log(logColors.muted(msg)),
-  notice: msg => console.log(logColors.green(msg)),
-  warn: msg => console.log(logColors.warning(msg)),
-  error: msg => console.log(logColors.error(msg)),
+  info: msg => log(logColors.muted(msg)),
+  notice: msg => log(logColors.green(msg)),
+  warn: msg => log(logColors.warning(msg)),
+  error: msg => log(logColors.error(msg)),
 };

--- a/src/logger/chalk-theme.ts
+++ b/src/logger/chalk-theme.ts
@@ -8,7 +8,7 @@ export const logColors = {
 };
 
 const log = (msg: string) => {
-  console.log(`${Date.now() / 1000}: ${msg}`);
+  console.log(`${new Date(Date.now()).toDateString()}: ${msg}`);
 }
 
 export const archLogger = {

--- a/src/models/archaeologist.ts
+++ b/src/models/archaeologist.ts
@@ -12,7 +12,7 @@ import { inMemoryStore } from "../utils/onchain-data";
 import { SarcophagusValidationError, StreamCommsError } from "../utils/error-codes";
 import type { Stream } from "@libp2p/interface-connection";
 import { signPacked } from "../utils/signature";
-import { getBlockTimestampMs } from "../utils/blockchain/helpers";
+import { getBlockTimestamp } from "../utils/blockchain/helpers";
 
 // If current block timestamp is further than the creation time passed to the arch
 // by this amount, then the arch will throw an error
@@ -182,12 +182,12 @@ export class Archaeologist {
               /**
                * Validate negotiation timestamp is within allowed drift of when we received this request
                */
-              if (timestamp > ((await getBlockTimestampMs()) + CREATION_TIMESTAMP_DRIFT_ALLOWED_MS)) {
+              if (timestamp > ((await getBlockTimestamp() * 1000) + CREATION_TIMESTAMP_DRIFT_ALLOWED_MS)) {
                 this.emitError(stream, {
                   code: SarcophagusValidationError.INVALID_TIMESTAMP,
                   message: `${errorMessagePrefix} \n Timestamp received is in the future.  
                   \n Got: ${timestamp}
-                  \n Latest block timestamp value: ${await getBlockTimestampMs()}`,
+                  \n Latest block timestamp value: ${await getBlockTimestamp()}`,
                 });
                 return;
               }

--- a/src/utils/blockchain/helpers.ts
+++ b/src/utils/blockchain/helpers.ts
@@ -30,15 +30,14 @@ function getRandomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-export const getBlockTimestampMs = async (): Promise<number> => {
+export const getBlockTimestamp = async (): Promise<number> => {
   try {
     const web3Interface = await getWeb3Interface();
     const provider = web3Interface.ethWallet.provider;
     const blockNumber = await provider.getBlockNumber();
     const block = await provider.getBlock(blockNumber);
 
-    // Converting the time to milliseconds as per javascript standard
-    return block.timestamp * 1000;
+    return block.timestamp;
   } catch (error) {
     // Not a good fallback, may want to institute a retry or failure (or notification)
     archLogger.warn(`Error retrieving block time: ${error}`);

--- a/src/utils/blockchain/refresh-data.ts
+++ b/src/utils/blockchain/refresh-data.ts
@@ -80,6 +80,7 @@ export async function fetchSarcophagiAndSchedulePublish(): Promise<SarcophagusDa
             resurrectionTime: scheduledResurrectionTime,
           });
         } else {
+          // Save inactive ones in memory to save RPC calls on next re-sync
           inMemoryStore.deadSarcophagusIds.push(sarcoId);
         }
       } catch (e) {

--- a/src/utils/blockchain/refresh-data.ts
+++ b/src/utils/blockchain/refresh-data.ts
@@ -45,7 +45,7 @@ export async function fetchSarcophagiAndSchedulePublish(): Promise<SarcophagusDa
           const tooLateToUnwrap =
             currentBlockTimestampSec > endOfGracePeriod(sarcophagus, inMemoryStore.gracePeriod!);
           if (tooLateToUnwrap) {
-            archLogger.warn(`Too late to unwrap: ${sarcoId} with resurrection time: ${sarcophagus.resurrectionTime.toNumber()} -- current time is ${Date.now() / 1000}`);
+            archLogger.debug(`Too late to unwrap: ${sarcoId} with resurrection time: ${sarcophagus.resurrectionTime.toNumber()} -- current time is ${Date.now() / 1000}`);
             return;
           }
 

--- a/src/utils/blockchain/refresh-data.ts
+++ b/src/utils/blockchain/refresh-data.ts
@@ -4,6 +4,7 @@ import { getGracePeriod, getSarcophagiIds, inMemoryStore, SarcophagusData } from
 import { BigNumber, ethers } from "ethers";
 import { handleRpcError } from "../rpc-error-handler";
 import { getBlockTimestampMs } from "./helpers";
+import { archLogger } from "../../logger/chalk-theme";
 
 // TODO -- once typechain defs are in the sarcophagus-org package,
 // the types in this file and onchain-data can get updated
@@ -46,12 +47,14 @@ export async function fetchSarcophagiAndSchedulePublish(): Promise<SarcophagusDa
           const tooLateToUnwrap =
             currentBlockTimestampSec > endOfGracePeriod(sarcophagus, inMemoryStore.gracePeriod!);
           if (tooLateToUnwrap) {
+            archLogger.warn(`Too late to unwrap: ${sarcoId} with resurrection time: ${sarcophagus.resurrectionTime.toNumber()} -- current time is ${Date.now() / 1000}`);
             return;
           }
 
           // Account for out of sync system clocks
           // Scheduler will use the system clock which may not be in sync with block.timestamp
           const systemClockDifference = (Date.now() / 1000) - currentBlockTimestampSec;
+          archLogger.notice(`systemClockDifference is ${systemClockDifference}`);
 
           // NOTE: If we are past the resurrection time (but still in the grace period)
           // Then schedule the unwrap for 5 seconds from now. Otherwise schedule for resurrection time

--- a/src/utils/health-check.ts
+++ b/src/utils/health-check.ts
@@ -12,7 +12,7 @@ import {
   OnchainProfile,
 } from "./onchain-data";
 import { formatFullPeerString, logBalances, logNotRegistered, logProfile } from "../cli/utils";
-import { getBlockTimestampMs } from "./blockchain/helpers";
+import { getBlockTimestamp } from "./blockchain/helpers";
 
 /**
  * Runs on service startup
@@ -53,7 +53,7 @@ export async function healthCheck(peerId?: string) {
       }
     }
 
-    const syncDifferenceSec = Math.abs(await getBlockTimestampMs() - Date.now()) / 1000;
+    const syncDifferenceSec = Math.abs((await getBlockTimestamp() * 1000) - Date.now()) / 1000;
     if (syncDifferenceSec >= 1800) {
       archLogger.warn(`Warning: your system clock is out of sync with universal UTC time by roughly: ${syncDifferenceSec} seconds`);
     }

--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -16,7 +16,7 @@ export function schedulePublishPrivateKey(sarcoId: string, date: Date) {
   }
 
   if (!scheduledPublishPrivateKey[sarcoId]) {
-    archLogger.notice(`Scheduling publish private key at: ${date.toString()}`);
+    archLogger.notice(`Scheduling unwrap for ${sarcoId} at: ${date.getTime() / 1000} (${date.toString()})`);
   }
 
   // Cancel existing schedules, so no duplicate jobs will be created.


### PR DESCRIPTION
During on-chain re-syncs, all sarcophagi were being cached (and thus skipped on subsequent refreshes), causing incorrect resurrection times on some sarcos (if they had been rewrapped / buried / etc).

This updates the caching to occur only on sarcos that are not active anymore (therefore we know there resurrection time won't change).

It also adds a lot of extra debug logging to the scheduling process.