### PR TITLE
refactor inactive sarco check into own method

### DIFF
--- a/src/utils/blockchain/refresh-data.ts
+++ b/src/utils/blockchain/refresh-data.ts
@@ -82,7 +82,7 @@ export async function fetchSarcophagiAndSchedulePublish(): Promise<SarcophagusDa
 
           archLogger.debug(`resurrection time with buffer: ${scheduledResurrectionTime}`);
 
-          schedulePublishPrivateKey(sarcoId, scheduledResurrectionTime);
+          schedulePublishPrivateKey(sarcoId, scheduledResurrectionTime, sarcophagus.resurrectionTime.toNumber());
 
           sarcophagi.push({
             id: sarcoId,

--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -4,8 +4,9 @@ import { publishPrivateKey } from "./blockchain/publish-private-key";
 import { inMemoryStore } from "./onchain-data";
 
 const scheduledPublishPrivateKey: Record<string, scheduler.Job | undefined> = {};
+const sarcoIdToResurrectionTime: Record<string, number> = {};
 
-export function schedulePublishPrivateKey(sarcoId: string, date: Date) {
+export function schedulePublishPrivateKey(sarcoId: string, resurrectionTime: Date, exactResurrectionTime: number) {
   // If sarcophagus is being unwrapped, dont schedule job
   const sarcoIndex = inMemoryStore.sarcoIdsInProcessOfHavingPrivateKeyPublished.findIndex(
     id => id === sarcoId
@@ -16,12 +17,20 @@ export function schedulePublishPrivateKey(sarcoId: string, date: Date) {
   }
 
   if (!scheduledPublishPrivateKey[sarcoId]) {
-    archLogger.notice(`Scheduling unwrap for ${sarcoId} at: ${date.getTime() / 1000} (${date.toString()})`);
+    archLogger.notice(`Scheduling unwrap for ${sarcoId} at: ${resurrectionTime.getTime() / 1000} (${resurrectionTime.toString()})`);
+  } else {
+    // If time is different than one in memory, a rewrap has occurred
+    if (sarcoIdToResurrectionTime[sarcoId] !== exactResurrectionTime) {
+      archLogger.notice(`Scheduling rewrap for ${sarcoId} at: ${resurrectionTime.getTime() / 1000} (${resurrectionTime.toString()})`);
+    }
   }
+
+  // Stored just for purposes of logging
+  sarcoIdToResurrectionTime[sarcoId] = exactResurrectionTime;
 
   // Cancel existing schedules, so no duplicate jobs will be created.
   scheduledPublishPrivateKey[sarcoId]?.cancel();
-  scheduledPublishPrivateKey[sarcoId] = scheduler.scheduleJob(date, async () => {
+  scheduledPublishPrivateKey[sarcoId] = scheduler.scheduleJob(resurrectionTime, async () => {
     await publishPrivateKey(sarcoId);
   });
 }


### PR DESCRIPTION
Refactor scheduler checks further to avoid throwing error with buried sarco timestamps in the logs.