### PR TITLE
update sarcophagus ids retrieval to use the graph

### DIFF
--- a/src/utils/blockchain/refresh-data.ts
+++ b/src/utils/blockchain/refresh-data.ts
@@ -5,7 +5,7 @@ import { BigNumber, ethers } from "ethers";
 import { handleRpcError } from "../rpc-error-handler";
 import { getBlockTimestamp, getDateFromTimestamp } from "./helpers";
 import { archLogger } from "../../logger/chalk-theme";
-import { SubgraphData } from "../../utils/graphql";
+import { SubgraphData } from "../graphql";
 
 const archStillNeedsToPublishPrivateKey = (archaeologist: any): boolean => {
   return archaeologist.privateKey === ethers.constants.HashZero;

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -152,7 +152,25 @@ export class SubgraphData {
   /**
    * Returns all sarcophagi that the archaeologist is cursed on, sourced
    * from subgraph. This DOES NOT include `cursedAmount` and `perSecondFee`
-   * and must be queryed separately from the contracts.
+   * and must be queried separately from the contracts.
+   */
+  static getSarcophagiIds = async (archAddress: string): Promise<string[]> => {
+    try {
+      const { sarcophagusDatas } = (await queryGraphQl(getArchSarcosQuery(archAddress))) as {
+        sarcophagusDatas: SarcoDataSubgraph[];
+      };
+
+      return sarcophagusDatas.map(s => s.sarcoId);
+    } catch (e) {
+      console.error(e);
+      return [];
+    }
+  };
+
+  /**
+   * Returns all sarcophagi that the archaeologist is cursed on, sourced
+   * from subgraph. This DOES NOT include `cursedAmount` and `perSecondFee`
+   * and must be queried separately from the contracts.
    */
   static getSarcophagi = async (): Promise<SarcophagusDataSimple[]> => {
     try {

--- a/src/utils/onchain-data.ts
+++ b/src/utils/onchain-data.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from "ethers";
 import { getWeb3Interface } from "../scripts/web3-interface";
 import { fetchSarcophagiAndSchedulePublish } from "./blockchain/refresh-data";
+import { SubgraphData } from "./graphql";
 
 export interface OnchainProfile {
   exists: boolean;
@@ -118,7 +119,7 @@ export async function getFreeBondBalance(): Promise<BigNumber> {
 
 export async function getSarcophagiIds(): Promise<string[]> {
   const web3Interface = await getWeb3Interface();
-  return web3Interface.viewStateFacet.getArchaeologistSarcophagi(web3Interface.ethWallet.address);
+  return SubgraphData.getSarcophagiIds(web3Interface.ethWallet.address.toLowerCase());
 }
 
 export enum SarcophagusState {


### PR DESCRIPTION
## Description
Remove dependency on `getArchaeologistSarcophagi`, as this struct is being removed from the contract. 

Uses graph query to return same data.