### PR TITLE
update diamond addy, subgraph addy + contracts version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@libp2p/webrtc-star-signalling-server": "^2.0.5",
     "@libp2p/websockets": "^5.0.1",
     "@mapbox/node-pre-gyp": "^1.0.10",
-    "@sarcophagus-org/sarcophagus-v2-contracts": "^0.16.0",
+    "@sarcophagus-org/sarcophagus-v2-contracts": "^0.17.1",
     "@types/node": "^18.0.0",
     "bip39": "^3.0.4",
     "chalk": "^5.0.1",

--- a/src/lib/config/goerli.ts
+++ b/src/lib/config/goerli.ts
@@ -5,6 +5,6 @@ export const goerliNetworkConfig: NetworkConfig = {
   networkName: "Goerli Testnet",
   networkShortName: "Goerli",
   sarcoTokenAddress: "0x4633b43990b41B57b3678c6F3Ac35bA75C3D8436",
-  diamondDeployAddress: "0x6B84f17bbfCe26776fEFDf5cF039cA0E66C46Caf",
-  subgraphUrl: "https://api.studio.thegraph.com/query/44302/sarcotest2/18",
+  diamondDeployAddress: "0x23205431DAa31e9b54d0EBF40e45CC03aC759a22",
+  subgraphUrl: "https://api.studio.thegraph.com/query/49076/sarco-goerli-test/two",
 };


### PR DESCRIPTION
## 
Use latest goerli deployment for pre-mainnet testing.