### PR TITLE
Replace Network Context when websockets fail

### DIFF
--- a/src/network-config.ts
+++ b/src/network-config.ts
@@ -57,7 +57,7 @@ const chainIdsToNetworkConfigReturningFunction = new Map<number, NetworkConfigRe
   [HARDHAT_CHAIN_ID, _ => hardhatNetworkConfig()],
 ]);
 
-const getNetworkContextByChainId = (chainId: number, isTest: boolean): NetworkContext => {
+export const getNetworkContextByChainId = (chainId: number, isTest: boolean = false): NetworkContext => {
   if (!chainIdsToNetworkConfigReturningFunction.has(chainId)) {
     throw Error(`Unsupported Chain ID: ${chainId}`);
   }
@@ -142,13 +142,13 @@ const getNetworkContextByChainId = (chainId: number, isTest: boolean): NetworkCo
 export const getNetworkContextsByChainIds = (
   chainIds: number[],
   isTest: boolean
-): NetworkContext[] => {
+): Set<NetworkContext> => {
   if (!chainIds.length) {
     throw Error("No chain IDs provided");
   }
 
-  const networkContexts: NetworkContext[] = [];
-  chainIds.forEach(chainId => networkContexts.push(getNetworkContextByChainId(chainId, isTest)));
+  const networkContexts: Set<NetworkContext> = new Set();
+  chainIds.forEach(chainId => networkContexts.add(getNetworkContextByChainId(chainId, isTest)));
 
   return networkContexts;
 };

--- a/src/scripts/web3-interface.ts
+++ b/src/scripts/web3-interface.ts
@@ -6,7 +6,7 @@ import { NetworkContext, getNetworkContextsByChainIds } from "../network-config"
 import { SARCO_SUPPORTED_NETWORKS } from "@sarcophagus-org/sarcophagus-v2-sdk";
 
 export interface Web3Interface {
-  networkContexts: NetworkContext[];
+  networkContexts: Set<NetworkContext>;
   getNetworkContext: (networkOrChainId: number | string | undefined) => NetworkContext;
 }
 
@@ -14,7 +14,7 @@ let web3Interface: Web3Interface | undefined;
 
 export const destroyWeb3Interface = async (): Promise<void> => {
   if (!!web3Interface) {
-    web3Interface.networkContexts.forEach(networkContext => {
+    [...web3Interface.networkContexts].forEach(networkContext => {
       networkContext.ethWallet.provider.removeAllListeners();
       (
         networkContext.ethWallet.provider as ethers.providers.WebSocketProvider
@@ -47,14 +47,14 @@ export const getWeb3Interface = async (isTest: boolean = false): Promise<Web3Int
         if (typeof networkOrChainId === "string") {
           const networkNames = Array.from(SARCO_SUPPORTED_NETWORKS.values());
           networkContext = networkNames.includes(networkOrChainId) ? 
-            web3Interface!.networkContexts.find(n => n.networkName.toLowerCase() === networkOrChainId.toLowerCase()) : 
+            [...web3Interface!.networkContexts].find(n => n.networkName.toLowerCase() === networkOrChainId.toLowerCase()) :
             undefined;
         }
 
         if (typeof networkOrChainId === "number") {
           const chainIds = Array.from(SARCO_SUPPORTED_NETWORKS.keys());
           networkContext = chainIds.includes(networkOrChainId) ? 
-            web3Interface!.networkContexts.find(n => n.chainId === networkOrChainId) : 
+            [...web3Interface!.networkContexts].find(n => n.chainId === networkOrChainId) :
             undefined;
         }
 

--- a/src/scripts/web3-interface.ts
+++ b/src/scripts/web3-interface.ts
@@ -68,6 +68,7 @@ export const getWeb3Interface = async (isTest: boolean = false): Promise<Web3Int
 
     return web3Interface;
   } catch (e) {
+    archLogger.info("failed on web3 interface create")
     await archLogger.error(e, { logTimestamp: true, sendNotification: true });
     exit(BAD_ENV);
   }

--- a/src/scripts/web3-interface.ts
+++ b/src/scripts/web3-interface.ts
@@ -12,18 +12,6 @@ export interface Web3Interface {
 
 let web3Interface: Web3Interface | undefined;
 
-export const destroyWeb3Interface = async (): Promise<void> => {
-  if (!!web3Interface) {
-    [...web3Interface.networkContexts].forEach(networkContext => {
-      networkContext.ethWallet.provider.removeAllListeners();
-      (
-        networkContext.ethWallet.provider as ethers.providers.WebSocketProvider
-      )._websocket.terminate();
-    });
-    web3Interface = undefined;
-  }
-};
-
 export const getWeb3Interface = async (isTest: boolean = false): Promise<Web3Interface> => {
   if (!!web3Interface) {
     return web3Interface;

--- a/src/start_service.ts
+++ b/src/start_service.ts
@@ -58,16 +58,6 @@ export async function startService(opts: {
     setInterval(async () => warnIfEthBalanceIsLow(networkContext), RESTART_INTERVAL);
   });
 
-  // temp manually force websockets close
-  setTimeout(async () => {
-    opts.networkContexts.forEach(async networkContext => {
-      const wsProvider = networkContext.ethWallet.provider as ethers.providers.WebSocketProvider
-      if (wsProvider._websocket) {
-        wsProvider._websocket.close();
-      }
-    })
-  }, 10000)
-
   await arch.initLibp2pNode();
   arch.setupSarcophagusNegotiationStreams();
 

--- a/src/start_service.ts
+++ b/src/start_service.ts
@@ -8,6 +8,7 @@ import { SIGNAL_SERVER_LIST } from "./models/node-config";
 import { archLogger } from "./logger/chalk-theme";
 import { setupEventListeners } from "./utils/contract-event-listeners";
 import { NetworkContext } from "./network-config";
+import { ethers } from "ethers";
 
 const RESTART_INTERVAL = 1_200_000; // 2O Minutes
 const CONTRACT_DATA_REFETCH_INTERVAL = process.env.REFETCH_INTERVAL
@@ -56,6 +57,16 @@ export async function startService(opts: {
     setupEventListeners(networkContext);
     setInterval(async () => warnIfEthBalanceIsLow(networkContext), RESTART_INTERVAL);
   });
+
+  // temp manually force websockets close
+  setTimeout(async () => {
+    opts.networkContexts.forEach(async networkContext => {
+      const wsProvider = networkContext.ethWallet.provider as ethers.providers.WebSocketProvider
+      if (wsProvider._websocket) {
+        wsProvider._websocket.close();
+      }
+    })
+  }, 10000)
 
   await arch.initLibp2pNode();
   arch.setupSarcophagusNegotiationStreams();

--- a/src/test/node_start.ts
+++ b/src/test/node_start.ts
@@ -39,7 +39,7 @@ export async function runTests() {
    *
    **/
   const web3Interface = await getWeb3Interface(true);
-  const networkContext = web3Interface.networkContexts[0];
+  const networkContext = [...web3Interface.networkContexts][0];
 
   // Remove ETH from account
   const bal = await networkContext.ethWallet.getBalance();

--- a/src/utils/contract-event-listeners.ts
+++ b/src/utils/contract-event-listeners.ts
@@ -41,15 +41,20 @@ function getCreateSarcoHandler(networkContext: NetworkContext) {
       ethWallet.address
     );
 
-    const block = await ethWallet.provider.getBlock(event.blockNumber);
-    const creationDate = getDateFromTimestamp(block.timestamp);
+    let creationDate;
+    try {
+      const block = await ethWallet.provider.getBlock(event.blockNumber);
+      creationDate = getDateFromTimestamp(block.timestamp);
+    } catch (error) {
+      archLogger.warn(`unable to get block timestamp: ${error}`)
+    }
 
     inMemoryStore.get(networkContext.chainId)!.sarcophagi.push({
       id: sarcoId,
       resurrectionTime: scheduledResurrectionTime,
       perSecondFee: archaeologist.diggingFeePerSecond,
       cursedAmount: archaeologist.curseFee,
-      creationDate,
+      creationDate: creationDate || Date.now(),
     });
   };
 }

--- a/src/utils/contract-event-listeners.ts
+++ b/src/utils/contract-event-listeners.ts
@@ -1,5 +1,5 @@
 import { exit } from "process";
-import { destroyWeb3Interface } from "../scripts/web3-interface";
+import { destroyWeb3Interface, getWeb3Interface } from "../scripts/web3-interface";
 import { RPC_EXCEPTION } from "./exit-codes";
 import { inMemoryStore } from "./onchain-data";
 import { archLogger } from "../logger/chalk-theme";
@@ -159,7 +159,8 @@ export async function setupEventListeners(networkContext: NetworkContext) {
         `[${networkContext.networkName}] Provider WS connection closed: ${e}. Reconnecting...`
       );
       await destroyWeb3Interface();
-      setupEventListeners(networkContext);
+      await getWeb3Interface()
+      setupEventListeners((await getWeb3Interface()).getNetworkContext(networkContext.chainId));
     });
   } catch (e) {
     console.error(e);

--- a/src/utils/contract-event-listeners.ts
+++ b/src/utils/contract-event-listeners.ts
@@ -123,6 +123,7 @@ function getAccuseHandler(networkContext: NetworkContext) {
 
 export async function setupEventListeners(networkContext: NetworkContext) {
   try {
+    archLogger.info("setting up event listeners")
     const { embalmerFacet, thirdPartyFacet, ethWallet } = networkContext;
     const filters = {
       createSarco: embalmerFacet.filters.CreateSarcophagus(),
@@ -131,7 +132,7 @@ export async function setupEventListeners(networkContext: NetworkContext) {
       bury: embalmerFacet.filters.BurySarcophagus(),
       accuse: thirdPartyFacet.filters.AccuseArchaeologist(),
     };
-
+    archLogger.info("setting up event listeners2")
     const handlers = {
       createSarco: getCreateSarcoHandler(networkContext),
       rewrap: getRewrapHandler(networkContext),
@@ -139,18 +140,24 @@ export async function setupEventListeners(networkContext: NetworkContext) {
       bury: getBuryHandler(networkContext),
       accuse: getAccuseHandler(networkContext),
     };
-
+    archLogger.info("setting up event listeners3")
     embalmerFacet.on(filters.createSarco, handlers.createSarco);
     embalmerFacet.on(filters.rewrap, handlers.rewrap);
     embalmerFacet.on(filters.clean, handlers.clean);
     embalmerFacet.on(filters.bury, handlers.bury);
     embalmerFacet.on(filters.accuse, handlers.accuse);
-
+    archLogger.info("setting up event listeners5")
     ethWallet.provider.on("error", async e => {
       archLogger.error(
         `[${networkContext.networkName}] Provider connection error: ${e}. Reconnecting...`
       );
+      archLogger.info("test6")
       await destroyWeb3Interface();
+      archLogger.info("test7")
+      await getWeb3Interface()
+      archLogger.info("test8")
+      networkContext = (await getWeb3Interface()).getNetworkContext(networkContext.chainId)
+      archLogger.info("test9")
       setupEventListeners(networkContext);
     });
 
@@ -158,9 +165,14 @@ export async function setupEventListeners(networkContext: NetworkContext) {
       archLogger.info(
         `[${networkContext.networkName}] Provider WS connection closed: ${e}. Reconnecting...`
       );
+      archLogger.info("test1")
       await destroyWeb3Interface();
+      archLogger.info("test2")
       await getWeb3Interface()
-      setupEventListeners((await getWeb3Interface()).getNetworkContext(networkContext.chainId));
+      archLogger.info("test3")
+      networkContext = (await getWeb3Interface()).getNetworkContext(networkContext.chainId)
+      archLogger.info("test4")
+      setupEventListeners(networkContext);
     });
   } catch (e) {
     console.error(e);

--- a/src/utils/contract-event-listeners.ts
+++ b/src/utils/contract-event-listeners.ts
@@ -159,7 +159,7 @@ export async function setupEventListeners(networkContext: NetworkContext) {
         `[${networkContext.networkName}] Provider WS connection closed: ${e}. Reconnecting...`
       );
 
-      const newNetworkContext: NetworkContext = getNetworkContextByChainId(4);
+      const newNetworkContext: NetworkContext = getNetworkContextByChainId(networkContext.chainId);
       (await getWeb3Interface()).networkContexts.delete(networkContext);
       (await getWeb3Interface()).networkContexts.add(newNetworkContext);
 


### PR DESCRIPTION
There was an issue with multiple websockets failing at one time across multiple networks that would lead to network context provider issues.

The web3 interface was updated to have the NetworkInterfaces as a Set, so that a specific network context could be replaced when websockets fail, and the new network context will have a re-instantiated websockets provider + facet connections.